### PR TITLE
Major Overhaul and Full Protocol (ish?) implementaiton

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -1,0 +1,182 @@
+# Hatch Rest BLE Protocol
+
+Reverse-engineered from btsnoop captures of the official Hatch app communicating with a 1st-generation Hatch Rest.
+
+---
+
+## GATT Characteristics
+
+| Name | UUID | Direction | Purpose |
+|---|---|---|---|
+| `CHAR_TX` | `02240002-5efd-47eb-9c1a-de53f7a2b232` | Write (no response) | Send commands to device |
+| `CHAR_LIST` | `02240003-5efd-47eb-9c1a-de53f7a2b232` | Notify | Config channel — favorites, schedules, timer, GF index |
+| `CHAR_FEEDBACK` | `02260002-5efd-47eb-9c1a-de53f7a2b232` | Notify / Read | State channel — power, color, sound, volume |
+
+All writes to `CHAR_TX` must use **write-without-response** (`response=False`). The device does not support GATT write-with-response on this characteristic.
+
+---
+
+## Manufacturer Advertisement Data
+
+Manufacturer ID: `1076` (0x0434)
+
+The advertisement payload uses the same tagged format as `CHAR_FEEDBACK`. Power state, color, sound, and volume are broadcast passively — no connection required for basic state monitoring.
+
+---
+
+## State Channel (`CHAR_FEEDBACK`)
+
+Responses use a tagged, variable-length format. Each section is identified by a marker byte:
+
+| Marker | Hex | Fields |
+|---|---|---|
+| `C` | `0x43` | R, G, B, brightness (1 byte each) |
+| `S` | `0x53` | sound ID, volume (1 byte each) |
+| `P` | `0x50` | power byte |
+
+**Power byte encoding:**
+
+- `0x00` — ON, no favorite active
+- `0x01`–`0x06` — ON, favorite N active (bits 0–5 = index)
+- `0x80` — OFF (favorite mode)
+- `0xC0` — OFF (manual mode)
+- `0x1F` — ON (special case)
+
+Rule: `power = not (byte & 0xC0) or byte == 0x1F`; `active_favorite = byte & 0x3F` (treat `0x3F`/`0x1F` as None)
+
+**Sound IDs:**
+
+| ID | Sound |
+|---|---|
+| 0 | None |
+| 2 | Stream |
+| 3 | White noise |
+| 4 | Dryer |
+| 5 | Ocean |
+| 6 | Wind |
+| 7 | Rain |
+| 9 | Bird |
+| 10 | Crickets |
+| 11 | Brahms |
+| 13 | Twinkle |
+| 14 | Rockabye |
+
+---
+
+## Commands (written to `CHAR_TX`)
+
+### Power
+
+| Command | Description |
+|---|---|
+| `SI01` | Turn on |
+| `SI00` | Turn off |
+
+### Light
+
+| Command | Description |
+|---|---|
+| `SC{RR}{GG}{BB}{LL}` | Set color (hex RGB) and brightness (hex). e.g. `SCff804064` |
+
+Setting color to `FEFEFE` activates gradient/rainbow mode.
+
+### Sound
+
+| Command | Description |
+|---|---|
+| `SN{NN}` | Set sound by ID (hex). e.g. `SN07` = rain |
+| `SV{VV}` | Set volume (hex 0–FF). e.g. `SV80` = 128 |
+
+### Timer
+
+| Command | Description |
+|---|---|
+| `SD{SSSS}` | Set timer — `SSSS` is duration in **seconds**, 4-digit hex. e.g. `SD0384` = 900s = 15 min |
+| `GI` | Query timer total — device replies `"FF"` (no timer) on `CHAR_LIST` |
+| `GD` | Query timer remaining — device replies 4-char ASCII hex **minutes** on `CHAR_LIST`. e.g. `"0076"` = 118 min |
+
+### Favorites
+
+| Command | Description |
+|---|---|
+| `GF` | Query active favorite index — device replies `"0{N}"` on `CHAR_LIST` |
+| `SP{NN}` | Activate favorite slot N (hex 01–06). `SP00` = deselect |
+| `PGB{NN}` | Read favorite slot N — device sends a 15-byte PGB block on `CHAR_LIST` |
+| `PSB{NN}` | Select slot to write |
+| `PSC{RR}{GG}{BB}{LL}` | Set slot color + brightness |
+| `PSN{NN}` | Set slot sound ID |
+| `PSV{VV}` | Set slot volume |
+| `PSL{FF}` | Set slot flags (`C0` = enabled, `80` = disabled) |
+| `PSF` | Commit — writes ALL fields atomically. **Must send PSB→PSC→PSN→PSV→PSL first.** |
+
+**PSF confirmation:** After `PSF`, the device sends `"01"` on `CHAR_LIST` — identical in format to a GF response. Gate GF parsing on a `_pending_gf` flag to avoid misreading this as active_favorite = 1.
+
+#### PGB Block Layout (15 bytes)
+
+```
+[0x01] [sound] [volume] [00 00 00 00 00 00] [brightness] [B] [G] [R] [flags] [0x03]
+  0       1       2       3  4  5  6  7  8       9         10  11  12    13     14
+```
+
+- `flags & 0x80` = enabled (`0x96` = enabled, `0x16` = disabled)
+- Color stored as BGR
+
+### Schedules
+
+| Command | Description |
+|---|---|
+| `EGB{NN}` | Read schedule slot N (hex 01–0A) — device sends a 20-byte EGB block on `CHAR_LIST` |
+| `ESB{NN}` | Select schedule slot to write |
+| `ESL{FF}` | Set schedule flags (`C0` = enabled, `80` = disabled) |
+| `ESF` | Commit schedule slot |
+
+#### EGB Block Layout (20 bytes)
+
+```
+[0x01] [unix_ts LE x4] [sound] [volume] [hour] [minute]
+  0       1  2  3  4     5       6        7       8
+
+[00 00 00 00] [brightness] [B] [G] [R] [0x00] [days] [flags]
+  9 10 11 12      13        14  15  16    17     18     19
+```
+
+- `flags & 0x40` = enabled
+- `days` bitmask: bit 0 = Sun, bit 1 = Mon, bit 2 = Tue, bit 3 = Wed, bit 4 = Thu, bit 5 = Fri, bit 6 = Sat
+
+### Clock Sync
+
+| Command | Description |
+|---|---|
+| `ST{YYYYMMDDHHmmss}U` | Set device clock. e.g. `ST20260420100000U` |
+
+Sent on every connection.
+
+### Miscellaneous
+
+| Command | Description |
+|---|---|
+| `GF` | Get active favorite index |
+
+---
+
+## Config Channel Notification Dispatch (`CHAR_LIST`)
+
+| Pattern | Meaning |
+|---|---|
+| `data == b"FF"` (2 bytes) | GI response — no timer active |
+| `len == 4`, all hex chars | GD response — remaining minutes (parse as `int(data, 16)`) |
+| `header == 0x30`, `_pending_gf` set | GF response — active favorite index is `data[1]` |
+| `header == 0x30`, `_pending_gf` not set | PSF/ESF save confirmation — ignore |
+| `header == 0x07` | ASCII name block for current slot |
+| `header == 0x01`, `len >= 20` | EGB schedule block |
+| `header == 0x01`, `13 <= len < 20` | PGB favorite block |
+| `data.startswith(b"OK")` | Device acknowledged command |
+
+---
+
+## Connection & Batching
+
+- Commands are batched per 10-second idle window using a `_send_lock`.
+- The connection is held open while `_active_operations > 0`; a 10-second disconnect timer fires after all operations complete.
+- On connect: subscribe to `CHAR_LIST` first (to avoid missing the initial dump), then `CHAR_FEEDBACK`; send `GF`; sync clock; fetch PGB01–PGB06 and EGB01–EGB0A if cache is stale (default TTL: 10 min).
+- Favorites cache is updated **in-place** on reconnect — never cleared — so toggle commands can read existing slot data even while fresh PGB responses are still arriving.

--- a/README.md
+++ b/README.md
@@ -1,26 +1,24 @@
 # Hatch Rest – Home Assistant Integration
 
-This is a custom Home Assistant integration for controlling the **Hatch Rest** (1st-generation) nightlight and sound machine over Bluetooth Low Energy (BLE).
+A custom Home Assistant integration for controlling the **Hatch Rest** (1st-generation) nightlight and sound machine over Bluetooth Low Energy (BLE).
 
-It provides a fully asynchronous, locally-controlled interface using a rewritten BLE API based on — and with gratitude to — the original work by **kjoconnor** in the `pyhatchbabyrest` project.
+Fully asynchronous and locally controlled — no cloud required. Built on a rewritten BLE API derived from the original work by **kjoconnor** in the `pyhatchbabyrest` project.
 
 ## ✨ Features
 
-* **Local BLE control** — no cloud required
-* **Efficient Connection Management** — Batches multiple commands into a single session and holds the connection open for 10 seconds of idle time to prevent "thrashing" the Bluetooth radio during heavy changes.
-* **Smart Refresh** — Detects physical changes via BLE advertisements and schedules a debounced deep refresh (10s) to keep HA perfectly in sync.
-* **Live Timer Tracking** — High-accuracy local timer estimation with a live-countdown `TIMESTAMP` sensor.
-* **Enhanced Reliability** — Uses "write with response" for all GATT commands and optimized batch sequencing to prevent device corruption.
-* **Configurable Polling** — Adjust the update frequency (default: 10 min) via the integration options flow.
-* **Dynamic Favorites** — Automatically filters the favorites list to only show those enabled in your Hatch settings.
-* **Full Protocol Support** — Comprehensive implementation of the Hatch Rest BLE protocol, including favorites (PGB), schedules (EGB), and timers (SD/GI/GD).
+* **Local BLE control** — no cloud, no account required
+* **Real-time updates** — state changes are picked up instantly via BLE advertisements and GATT notifications; no polling required for basic state
+* **Efficient connections** — commands are batched into a single BLE session; the connection is held open for 10 seconds of idle time before disconnecting, preventing radio thrash during rapid changes
+* **Full favorites support** — reads all 6 favorite slots on connect, enables/disables slots without overwriting their content, and exposes only enabled favorites in the selector
+* **Schedule support** — reads all 10 schedule slots and exposes enable/disable toggles for each
+* **Timer control** — set and monitor a sleep timer; the remaining time is shown as a live-countdown sensor
+* **Configurable refresh interval** — adjust how often the integration re-fetches favorites and schedules via the options flow (default: 10 minutes)
 
 ## 📦 Installation
 
 ### HACS
 
-1. Add this repository as a **Custom Repository**
-   *(HACS → Integrations → Custom Repositories)*
+1. Add this repository as a **Custom Repository** *(HACS → Integrations → Custom Repositories)*
 2. Search for **Hatch Rest**
 3. Install → Restart Home Assistant
 
@@ -29,37 +27,26 @@ It provides a fully asynchronous, locally-controlled interface using a rewritten
 1. Go to **Settings → Devices & Services → Add Integration**
 2. Search for **Hatch Rest**
 3. Choose your discovered device from the list
-4. Configure the **Scan Interval** (default is 10 minutes)
+4. Configure the **Scan Interval** (default: 10 minutes)
 5. Done!
 
-## 🧩 Supported Entities
+## 🧩 Entities
 
-### 🔌 Switch
-* **Master Switch**: Main power state of the device.
-* **Favorite Enabled**: Configuration toggles to enable or disable specific favorite slots.
-* **Schedule Enabled**: Configuration toggles to enable or disable specific schedule slots.
-
-### 🟡 Light
-* RGB color and brightness control.
-
-### 🔊 Media Player
-* Sound selection and volume control.
-
-### 📋 Select
-* **Favorite**: Quickly switch between your pre-configured favorites. Only enabled favorites are shown.
-
-### ⏲️ Sensor
-* **Timer Remaining**: A live-updating timestamp sensor showing when the active timer will expire.
-
-### 🔢 Number
-* **Set Timer**: A numeric input to quickly set a timer (in minutes) from the dashboard.
+| Platform | Entity | Description |
+|---|---|---|
+| **Switch** | Power | Master on/off |
+| **Switch** | Favorite *N* Enabled | Enable or disable a favorite slot (1–6) |
+| **Switch** | Schedule *N* Enabled | Enable or disable a schedule slot (1–10) |
+| **Light** | Light | RGB color and brightness |
+| **Media Player** | Media Player | Sound selection and volume |
+| **Select** | Favorite | Switch between enabled favorites |
+| **Number** | Set Timer | Set a sleep timer (in minutes) |
+| **Sensor** | Timer Remaining | Countdown timestamp showing when the timer expires |
 
 ## 📡 Bluetooth Requirements
 
-Because the Hatch Rest is a BLE device:
-
-* A compatible Home Assistant Bluetooth controller is required.
-* This integration uses `bleak_retry_connector` for robust connection management.
+* A compatible Home Assistant Bluetooth controller is required
+* This integration uses `bleak_retry_connector` for robust, retry-aware connection management
 
 ## 🧪 Contributing
 

--- a/README.md
+++ b/README.md
@@ -7,10 +7,13 @@ It provides a fully asynchronous, locally-controlled interface using a rewritten
 ## ✨ Features
 
 * **Local BLE control** — no cloud required
-* **Three (3) entities exposed:**
-  * Light (RGB + brightness)
-  * Switch (main power)
-  * Media Player (sounds + volume)
+* **Efficient Connection Management** — Batches multiple commands into a single session and holds the connection open for 10 seconds of idle time to prevent "thrashing" the Bluetooth radio during heavy changes.
+* **Smart Refresh** — Detects physical changes via BLE advertisements and schedules a debounced deep refresh (10s) to keep HA perfectly in sync.
+* **Live Timer Tracking** — High-accuracy local timer estimation with a live-countdown `TIMESTAMP` sensor.
+* **Enhanced Reliability** — Uses "write with response" for all GATT commands and optimized batch sequencing to prevent device corruption.
+* **Configurable Polling** — Adjust the update frequency (default: 10 min) via the integration options flow.
+* **Dynamic Favorites** — Automatically filters the favorites list to only show those enabled in your Hatch settings.
+* **Full Protocol Support** — Comprehensive implementation of the Hatch Rest BLE protocol, including favorites (PGB), schedules (EGB), and timers (SD/GI/GD).
 
 ## 📦 Installation
 
@@ -26,34 +29,38 @@ It provides a fully asynchronous, locally-controlled interface using a rewritten
 1. Go to **Settings → Devices & Services → Add Integration**
 2. Search for **Hatch Rest**
 3. Choose your discovered device from the list
-4. Confirm the Bluetooth address
+4. Configure the **Scan Interval** (default is 10 minutes)
 5. Done!
 
 ## 🧩 Supported Entities
 
 ### 🔌 Switch
-* Master on/off power state of the device
+* **Master Switch**: Main power state of the device.
+* **Favorite Enabled**: Configuration toggles to enable or disable specific favorite slots.
+* **Schedule Enabled**: Configuration toggles to enable or disable specific schedule slots.
 
 ### 🟡 Light
+* RGB color and brightness control.
 
 ### 🔊 Media Player
+* Sound selection and volume control.
+
+### 📋 Select
+* **Favorite**: Quickly switch between your pre-configured favorites. Only enabled favorites are shown.
+
+### ⏲️ Sensor
+* **Timer Remaining**: A live-updating timestamp sensor showing when the active timer will expire.
+
+### 🔢 Number
+* **Set Timer**: A numeric input to quickly set a timer (in minutes) from the dashboard.
 
 ## 📡 Bluetooth Requirements
 
 Because the Hatch Rest is a BLE device:
 
-* A compatible Home Assistant Bluetooth controller is required
-
-
-This integration uses BLE connections aggressively but cleanly:
-
-* Queues operations
-* Avoids simultaneous connects
-* Disconnects when idle
-* Automatically retries on common BLE failures
+* A compatible Home Assistant Bluetooth controller is required.
+* This integration uses `bleak_retry_connector` for robust connection management.
 
 ## 🧪 Contributing
 
 Issues and PRs are welcome!
-
-If you improve the async BLE API or add new services (timers, programs, gradients), feel free to submit a pull request.

--- a/custom_components/hatch_rest/__init__.py
+++ b/custom_components/hatch_rest/__init__.py
@@ -1,12 +1,17 @@
 """Hatch Rest integration."""
 
+import logging
+
 from homeassistant import config_entries, core
 from homeassistant.components import bluetooth
 from homeassistant.const import CONF_ADDRESS, Platform
 from homeassistant.exceptions import ConfigEntryNotReady
 
 from .api import PyHatchBabyRestAsync
+from .const import DOMAIN
 from .coordinator import HatchBabyRestUpdateCoordinator
+
+_LOGGER = logging.getLogger(__name__)
 
 PLATFORMS = [Platform.LIGHT, Platform.MEDIA_PLAYER, Platform.SWITCH]
 

--- a/custom_components/hatch_rest/__init__.py
+++ b/custom_components/hatch_rest/__init__.py
@@ -1,5 +1,6 @@
 """Hatch Rest integration."""
 
+from datetime import timedelta
 import logging
 
 from homeassistant import config_entries, core
@@ -8,12 +9,19 @@ from homeassistant.const import CONF_ADDRESS, Platform
 from homeassistant.exceptions import ConfigEntryNotReady
 
 from .api import PyHatchBabyRestAsync
-from .const import DOMAIN
+from .const import CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL, DOMAIN
 from .coordinator import HatchBabyRestUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
-PLATFORMS = [Platform.LIGHT, Platform.MEDIA_PLAYER, Platform.SWITCH]
+PLATFORMS = [
+    Platform.LIGHT,
+    Platform.MEDIA_PLAYER,
+    Platform.SWITCH,
+    Platform.SENSOR,
+    Platform.NUMBER,
+    Platform.SELECT,
+]
 
 
 # async_setup_entry handles the setup of individual configuration
@@ -24,16 +32,25 @@ async def async_setup_entry(
     """Set up the Hatch Rest component."""
 
     address = entry.data[CONF_ADDRESS]
+    scan_interval_min = entry.options.get(
+        CONF_SCAN_INTERVAL, entry.data.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
+    )
+    scan_interval = timedelta(minutes=scan_interval_min)
+
     ble_device = bluetooth.async_ble_device_from_address(hass, address.upper())
     if not ble_device:
         raise ConfigEntryNotReady(
             f"Could not find Hatch Rest device with address {address}"
         )
     hatch_rest_device = PyHatchBabyRestAsync(ble_device)
+    hatch_rest_device.full_refresh_interval = (
+        scan_interval_min * 60
+    )  # convert to seconds
     coordinator = HatchBabyRestUpdateCoordinator(
         hass,
         entry.unique_id,
         hatch_rest_device,
+        update_interval=scan_interval,
     )
     entry.runtime_data = coordinator
 
@@ -42,6 +59,7 @@ async def async_setup_entry(
         lambda: hatch_rest_device.remove_callback(coordinator._handle_api_update)
     )
     entry.async_on_unload(coordinator._cancel_bluetooth_advertisements)
+    entry.async_on_unload(entry.add_update_listener(options_update_listener))
 
     # Fetch initial data so we have data when entities subscribe
     #

--- a/custom_components/hatch_rest/__init__.py
+++ b/custom_components/hatch_rest/__init__.py
@@ -36,6 +36,7 @@ async def async_setup_entry(
     entry.async_on_unload(
         lambda: hatch_rest_device.remove_callback(coordinator._handle_api_update)
     )
+    entry.async_on_unload(coordinator._cancel_bluetooth_advertisements)
 
     # Fetch initial data so we have data when entities subscribe
     #

--- a/custom_components/hatch_rest/__init__.py
+++ b/custom_components/hatch_rest/__init__.py
@@ -32,6 +32,11 @@ async def async_setup_entry(
     )
     entry.runtime_data = coordinator
 
+    # Register a callback to remove the coordinator listener on unload
+    entry.async_on_unload(
+        lambda: hatch_rest_device.remove_callback(coordinator._handle_api_update)
+    )
+
     # Fetch initial data so we have data when entities subscribe
     #
     # If the refresh fails, async_config_entry_first_refresh will

--- a/custom_components/hatch_rest/api.py
+++ b/custom_components/hatch_rest/api.py
@@ -6,6 +6,7 @@ https://github.com/kjoconnor/pyhatchbabyrest/blob/master/LICENSE
 
 """
 
+from collections.abc import Callable
 import asyncio
 from datetime import datetime
 import logging
@@ -46,6 +47,8 @@ class PyHatchBabyRestAsync:
         self._connection_cv = asyncio.Condition()
         self._connecting: bool = False
         self._disconnect_timer: asyncio.TimerHandle | None = None
+        self._callbacks: set[Callable[[], None]] = set()
+        self._is_notifying: bool = False
 
         # cached device state
         self.color: tuple[int, int, int] | None = None
@@ -53,6 +56,39 @@ class PyHatchBabyRestAsync:
         self.sound: PyHatchBabyRestSound | None = None
         self.volume: int | None = None
         self.power: bool | None = None
+
+    def update_ble_device(self, ble_device: BLEDevice) -> None:
+        """Update the BLE device."""
+        self.device = ble_device
+        self.address = ble_device.address
+
+    def update_from_advertisement(self, service_info: "BluetoothServiceInfoBleak") -> None:
+        """Update state from advertisement data."""
+        from .const import MANUFACTURER_ID
+
+        if MANUFACTURER_ID not in service_info.manufacturer_data:
+            return
+
+        data = service_info.manufacturer_data[MANUFACTURER_ID]
+        _LOGGER.debug("Received advertisement data: %s", data.hex())
+
+        # The advertisement data format for Hatch Rest varies, but some versions
+        # include status bytes. If yours does, we can parse it here.
+        # For now, we update the BLEDevice so the next connection is faster.
+        self.update_ble_device(service_info.device)
+
+    def register_callback(self, callback: Callable[[], None]) -> None:
+        """Register a callback for when data is updated."""
+        self._callbacks.add(callback)
+
+    def remove_callback(self, callback: Callable[[], None]) -> None:
+        """Remove a previously registered callback."""
+        self._callbacks.discard(callback)
+
+    def _notify_callbacks(self) -> None:
+        """Notify all registered callbacks of an update."""
+        for callback in self._callbacks:
+            callback()
 
     def _set_active_operations(self, amount: int):
         """Change the number of running tasks."""
@@ -68,6 +104,7 @@ class PyHatchBabyRestAsync:
         """Callback for when the client disconnects."""
         _LOGGER.debug("API client has successfully disconnected")
         self._client = None
+        self._is_notifying = False
         if self._disconnect_timer:
             self._disconnect_timer.cancel()
             self._disconnect_timer = None
@@ -102,10 +139,19 @@ class PyHatchBabyRestAsync:
             client = await establish_connection(
                 BleakClientWithServiceCache,
                 self.device,
-                self.device.address,
+                self.address,
                 disconnected_callback=self._client_disconnected,
             )
             _LOGGER.debug("Client connected: %s", client.is_connected)
+
+            # Start notifications if supported
+            if client.is_connected and not self._is_notifying:
+                try:
+                    _LOGGER.debug("Starting notifications on %s", CHAR_FEEDBACK)
+                    await client.start_notify(CHAR_FEEDBACK, self._notification_handler)
+                    self._is_notifying = True
+                except Exception as e:
+                    _LOGGER.warning("Could not start notifications: %r", e)
 
         except (
             BleakNotFoundError,
@@ -175,11 +221,14 @@ class PyHatchBabyRestAsync:
         await self._client_connect()
 
         try:
-            await self._client.write_gatt_char(  # pyright: ignore[reportOptionalMemberAccess]
-                char_specifier=CHAR_TX,
-                data=bytearray(command, "utf-8"),
-                response=True,
-            )
+            if self._client and self._client.is_connected:
+                await self._client.write_gatt_char(
+                    char_specifier=CHAR_TX,
+                    data=bytearray(command, "utf-8"),
+                    response=True,
+                )
+            else:
+                _LOGGER.warning("Could not send command: Not connected to device")
 
         except (
             BleakNotFoundError,
@@ -200,6 +249,58 @@ class PyHatchBabyRestAsync:
                 monotonic() - start,  # pyright: ignore[reportPossiblyUnboundVariable]
             )
 
+    def _notification_handler(self, characteristic: int, data: bytearray) -> None:
+        """Handle incoming notifications from the device."""
+        # _parse_data already handles the logic and "CHANGED" logging
+        self._parse_data(data)
+        self._notify_callbacks()
+
+    def _parse_data(self, data: bytearray) -> None:
+        """Parse raw device data and update state."""
+        response = [hex(x) for x in data]
+
+        # Make sure the data is where we think it is
+        try:
+            _assert_value(response, 5, "0x43")  # color
+            _assert_value(response, 10, "0x53")  # audio
+            _assert_value(response, 13, "0x50")  # power
+
+            red, green, blue, brightness = [int(x, 16) for x in response[6:10]]
+            sound = PyHatchBabyRestSound(int(response[11], 16))
+            volume = int(response[12], 16)
+            power = not bool(int("11000000", 2) & int(response[14], 16))
+
+            new_color = (red, green, blue)
+
+            # Check if anything has actually changed
+            if (
+                new_color == self.color
+                and brightness == self.brightness
+                and sound == self.sound
+                and volume == self.volume
+                and power == self.power
+            ):
+                _LOGGER.debug("State unchanged, skipping callback")
+                return
+
+            self.color = new_color
+            self.brightness = brightness
+            self.sound = sound
+            self.volume = volume
+            self.power = power
+
+            _LOGGER.debug(
+                "Parsed state (CHANGED): power=%s, brightness=%s, color=%s, sound=%s, volume=%s",
+                self.power,
+                self.brightness,
+                self.color,
+                self.sound,
+                self.volume,
+            )
+            self._notify_callbacks()
+        except (ValueError, IndexError) as e:
+            _LOGGER.warning("Failed to parse device data: %r", e)
+
     async def refresh_data(self):
         """Refresh data from Hatch Rest device."""
         if log_timing := _LOGGER.isEnabledFor(logging.DEBUG):
@@ -210,33 +311,12 @@ class PyHatchBabyRestAsync:
         await self._client_connect()
 
         try:
-            raw_char_read = await self._client.read_gatt_char(CHAR_FEEDBACK)  # pyright: ignore[reportOptionalMemberAccess]
-            _LOGGER.debug("Raw char read from refresh_data: %s", raw_char_read)
-
-            response = [hex(x) for x in raw_char_read]
-
-            # Make sure the data is where we think it is
-            _assert_value(response, 5, "0x43")  # color
-            _assert_value(response, 10, "0x53")  # audio
-            _assert_value(response, 13, "0x50")  # power
-
-            red, green, blue, brightness = [int(x, 16) for x in response[6:10]]
-
-            sound = PyHatchBabyRestSound(int(response[11], 16))
-            volume = int(response[12], 16)
-
-            power = not bool(int("11000000", 2) & int(response[14], 16))
-
-            self.color = (red, green, blue)
-            _LOGGER.debug("refresh_data color: %s", self.color)
-            self.brightness = brightness
-            _LOGGER.debug("refresh_data brightness: %s", self.brightness)
-            self.sound = sound
-            _LOGGER.debug("refresh_data sound: %s", self.sound)
-            self.volume = volume
-            _LOGGER.debug("refresh_data volume: %s", self.volume)
-            self.power = power
-            _LOGGER.debug("refresh_data power: %s", self.power)
+            if self._client and self._client.is_connected:
+                raw_char_read = await self._client.read_gatt_char(CHAR_FEEDBACK)
+                _LOGGER.debug("Raw char read from refresh_data: %s", raw_char_read)
+                self._parse_data(raw_char_read)
+            else:
+                _LOGGER.warning("Could not refresh data: Not connected to device")
 
         except (
             BleakNotFoundError,
@@ -256,6 +336,7 @@ class PyHatchBabyRestAsync:
                 datetime.now().isoformat(),
                 monotonic() - start,  # pyright: ignore[reportPossiblyUnboundVariable]
             )
+
 
     async def turn_power_on(self):
         """Power on the Hatch Rest device."""

--- a/custom_components/hatch_rest/api.py
+++ b/custom_components/hatch_rest/api.py
@@ -81,8 +81,7 @@ class PyHatchBabyRestAsync:
         self.update_ble_device(service_info.device)
 
         # Parse the advertisement data (it uses the same tagged format)
-        if self._parse_data(data):
-            self._notify_callbacks()
+        self._parse_data(data)
 
     def register_callback(self, callback: Callable[[], None]) -> None:
         """Register a callback for when data is updated."""
@@ -158,12 +157,22 @@ class PyHatchBabyRestAsync:
                     await client.start_notify(CHAR_FEEDBACK, self._notification_handler)
                     
                     self._is_notifying = True
+
                     # GF returns the active favorite index. Then PGB01-PGB06
                     # fetches each slot's config+name. Both confirmed via btsnoop.
                     _LOGGER.debug("Requesting active favorite index via 'GF'")
                     await client.write_gatt_char(
                         CHAR_TX, bytearray(b"GF"), response=False
                     )
+
+                    # Sync clock on every connection
+                    now = datetime.now()
+                    clock_cmd = f"ST{now.strftime('%Y%m%d%H%M%S')}U"
+                    _LOGGER.debug("Syncing clock: %s", clock_cmd)
+                    await client.write_gatt_char(
+                        CHAR_TX, bytearray(clock_cmd, "utf-8"), response=False
+                    )
+
                     fetch_age = monotonic() - self._last_full_fetch if self._last_full_fetch else None
                     if fetch_age is None or fetch_age > 3600:
                         _LOGGER.debug("Fetching favorites and schedules (age=%s)", fetch_age)
@@ -242,30 +251,47 @@ class PyHatchBabyRestAsync:
                 self._active_operations,
             )
 
-    async def _send_command(self, command: str, raw: bool = False):
-        """Send a command to the device.
+    async def _send_commands(
+        self,
+        commands: list[str],
+        raw: bool = False,
+        response: bool = True,
+        spacing_delay: float = 0.2,
+    ):
+        """Send a batch of commands to the device.
 
-        :param command: ASCII command string, or hex-encoded bytes if raw=True.
+        :param commands: List of ASCII command strings.
         :param raw: If True, decode command as hex string and send raw bytes.
+        :param response: If True, wait for GATT-level acknowledgment.
+        :param spacing_delay: Seconds to wait between commands in a batch.
         """
         if log_timing := _LOGGER.isEnabledFor(logging.DEBUG):
             start = monotonic()
-            _LOGGER.debug("Started _send_command at %s", datetime.now().isoformat())
+            _LOGGER.debug(
+                "Started batch _send_commands at %s", datetime.now().isoformat()
+            )
 
         self._set_active_operations(1)
         await self._client_connect()
 
         try:
             if self._client and self._client.is_connected:
-                data = bytearray.fromhex(command) if raw else bytearray(command, "utf-8")
-                _LOGGER.debug("Sending command '%s' (Hex: %s)", command, data.hex())
-                await self._client.write_gatt_char(
-                    char_specifier=CHAR_TX,
-                    data=data,
-                    response=False,
-                )
+                for i, command in enumerate(commands):
+                    data = (
+                        bytearray.fromhex(command)
+                        if raw
+                        else bytearray(command, "utf-8")
+                    )
+                    _LOGGER.debug("Sending command '%s' (Hex: %s)", command, data.hex())
+                    await self._client.write_gatt_char(
+                        char_specifier=CHAR_TX,
+                        data=data,
+                        response=response,
+                    )
+                    if i < len(commands) - 1 and spacing_delay > 0:
+                        await asyncio.sleep(spacing_delay)
             else:
-                _LOGGER.warning("Could not send command: Not connected to device")
+                _LOGGER.warning("Could not send commands: Not connected to device")
 
         except (
             BleakNotFoundError,
@@ -274,17 +300,21 @@ class PyHatchBabyRestAsync:
             BleakConnectionError,
             Exception,  # noqa: BLE001
         ) as e:
-            _LOGGER.warning("Exception during _send_command -- %r", e)
+            _LOGGER.warning("Exception during _send_commands -- %r", e)
 
         self._set_active_operations(-1)
         self._schedule_disconnect()
 
         if log_timing:
             _LOGGER.debug(
-                "Finished _send_command at %s (total of %.3f seconds)",
+                "Finished batch _send_commands at %s (total of %.3f seconds)",
                 datetime.now().isoformat(),
                 monotonic() - start,  # pyright: ignore[reportPossiblyUnboundVariable]
             )
+
+    async def _send_command(self, command: str, raw: bool = False, response: bool = True):
+        """Send a single command to the device."""
+        return await self._send_commands([command], raw=raw, response=response, spacing_delay=0)
 
     def _notification_handler(self, char_specifier, data: bytearray) -> None:
         """Handle incoming notifications from the device."""
@@ -307,9 +337,8 @@ class PyHatchBabyRestAsync:
 
         if is_config:
             self._parse_config_data(data)
-            self._notify_callbacks()
-        elif self._parse_data(data):
-            self._notify_callbacks()
+        else:
+            self._parse_data(data)
 
     @staticmethod
     def _decode_config_block(data: bytearray) -> dict:
@@ -390,6 +419,7 @@ class PyHatchBabyRestAsync:
 
         _LOGGER.debug("[Config] Hex: %s | ASCII: %s", data.hex(), data.decode("utf-8", errors="ignore"))
 
+        changed = False
         try:
             header = data[0]
             
@@ -398,18 +428,10 @@ class PyHatchBabyRestAsync:
                 index_str = data[1:2].decode("utf-8", errors="ignore")
                 if index_str.isdigit():
                     index = int(index_str)
-                    _LOGGER.debug("Active index (0x30): %d", index)
-                    self.active_favorite = index
-                    self._last_index_seen = index
-                    self._flush_pending_slot(index)
-
-            # Header 0x45 ('E') is another Index block
-            elif header == 0x45 and len(data) >= 3:
-                index_str = data[1:3].decode("utf-8", errors="ignore")
-                if index_str.isdigit():
-                    index = int(index_str)
-                    _LOGGER.debug("Active index (0x45): %d", index)
-                    self.active_favorite = index
+                    if self.active_favorite != index:
+                        _LOGGER.debug("Active index (0x30): %d", index)
+                        self.active_favorite = index
+                        changed = True
                     self._last_index_seen = index
                     self._flush_pending_slot(index)
 
@@ -427,31 +449,45 @@ class PyHatchBabyRestAsync:
                 name = name_bytes.decode("utf-8", errors="ignore").strip()
                 if name:
                     if self._egb_slot is not None:
-                        _LOGGER.debug("Schedule name '%s' (slot %d)", name, self._egb_slot)
-                        self.schedules.setdefault(self._egb_slot, {})["name"] = name
+                        slot_dict = self.schedules.setdefault(self._egb_slot, {})
+                        if slot_dict.get("name") != name:
+                            _LOGGER.debug("Schedule name '%s' (slot %d)", name, self._egb_slot)
+                            slot_dict["name"] = name
+                            changed = True
                     elif self._last_index_seen is None:
-                        _LOGGER.debug("Buffering name '%s' (index not yet known)", name)
-                        self._pending_slot["name"] = name
+                        if self._pending_slot.get("name") != name:
+                            _LOGGER.debug("Buffering name '%s' (index not yet known)", name)
+                            self._pending_slot["name"] = name
                     else:
-                        _LOGGER.debug("Captured name '%s' (index %d)", name, self._last_index_seen)
-                        self.schedules.setdefault(self._last_index_seen, {})["name"] = name
+                        slot_dict = self.schedules.setdefault(self._last_index_seen, {})
+                        if slot_dict.get("name") != name:
+                            _LOGGER.debug("Captured name '%s' (index %d)", name, self._last_index_seen)
+                            slot_dict["name"] = name
+                            changed = True
 
             # Header 0x01 — 15-byte = favorite (PGB), 20-byte = schedule (EGB)
             elif header == 0x01 and len(data) >= 13:
                 if len(data) >= 20:
                     parsed = self._decode_schedule_block(data)
                     idx = self._egb_slot or self._last_index_seen
-                    _LOGGER.debug("Schedule config slot %s: %s", idx, parsed)
                     if idx is not None:
-                        self.schedules.setdefault(idx, {}).update(parsed)
+                        slot_dict = self.schedules.setdefault(idx, {})
+                        if any(slot_dict.get(k) != v for k, v in parsed.items()):
+                            _LOGGER.debug("Schedule config slot %s: %s", idx, parsed)
+                            slot_dict.update(parsed)
+                            changed = True
                 else:
                     parsed = self._decode_config_block(data)
-                    _LOGGER.debug("Favorite config slot %s: %s", self._pgb_slot, parsed)
                     idx = self._pgb_slot or self._last_index_seen
                     if idx is None:
-                        self._pending_slot.update(parsed)
+                        if any(self._pending_slot.get(k) != v for k, v in parsed.items()):
+                            self._pending_slot.update(parsed)
                     else:
-                        self.favorites.setdefault(idx, {}).update(parsed)
+                        slot_dict = self.favorites.setdefault(idx, {})
+                        if any(slot_dict.get(k) != v for k, v in parsed.items()):
+                            _LOGGER.debug("Favorite config slot %s: %s", self._pgb_slot, parsed)
+                            slot_dict.update(parsed)
+                            changed = True
 
             # Header 0x4F ('OK')
             elif data.startswith(b"OK"):
@@ -459,9 +495,12 @@ class PyHatchBabyRestAsync:
 
         except Exception as e:
             _LOGGER.debug("Failed to parse config notification: %r", e)
+        
+        if changed:
+            self._notify_callbacks()
 
-    def _parse_data(self, data: bytearray) -> bool:
-        """Parse raw device data and update state. Returns True if state changed."""
+    def _parse_data(self, data: bytearray) -> None:
+        """Parse raw device data and update state."""
         _LOGGER.debug("Parsing raw data: %s", data.hex())
         try:
             # Find Color Section 'C' (0x43)
@@ -482,7 +521,7 @@ class PyHatchBabyRestAsync:
                     new_sound = PyHatchBabyRestSound(sound_id)
                 except ValueError:
                     _LOGGER.debug("Unknown sound ID received: %d", sound_id)
-                    new_sound = self.sound # Keep current if unknown
+                    new_sound = sound_id
                 new_volume = data[s_idx + 2]
             else:
                 new_sound = self.sound
@@ -491,9 +530,20 @@ class PyHatchBabyRestAsync:
             # Find Power Section 'P' (0x50)
             p_idx = data.find(0x50)
             if p_idx != -1 and len(data) >= p_idx + 2:
-                new_power = not bool(int("11000000", 2) & data[p_idx + 1])
+                # We revert to the robust power logic: bits 7 & 6 OFF means device is ON.
+                # Standard Hatch: 0xC0=OFF (Manual), 0x80=OFF (Favorite?), 0x00=ON (Manual), 0x01=ON (Fav1).
+                # User fix: bool(power_byte & 0x40) or (power_byte == 0x1f)
+                # Reverting to the logic from ~2 commits ago as requested:
+                power_byte = data[p_idx + 1]
+                new_power = not bool(int("11000000", 2) & power_byte) or (power_byte == 0x1f)
+                
+                # Active favorite index is bits 0-5
+                new_favorite = power_byte & 0x3F
+                if new_favorite == 0x3F or new_favorite == 31:
+                    new_favorite = None
             else:
                 new_power = self.power
+                new_favorite = self.active_favorite
 
             if (
                 new_color == self.color
@@ -501,23 +551,24 @@ class PyHatchBabyRestAsync:
                 and new_sound == self.sound
                 and new_volume == self.volume
                 and new_power == self.power
+                and new_favorite == self.active_favorite
             ):
-                return False
+                return
 
             self.color = new_color
             self.brightness = new_brightness
             self.sound = new_sound
             self.volume = new_volume
             self.power = new_power
+            self.active_favorite = new_favorite
 
             _LOGGER.debug(
-                "Parsed state (CHANGED): power=%s, brightness=%s, color=%s, sound=%s, volume=%s",
-                self.power, self.brightness, self.color, self.sound, self.volume,
+                "Parsed state (CHANGED): power=%s, brightness=%s, color=%s, sound=%s, volume=%s, active_favorite=%s",
+                self.power, self.brightness, self.color, self.sound, self.volume, self.active_favorite,
             )
-            return True
+            self._notify_callbacks()
         except (ValueError, IndexError) as e:
             _LOGGER.warning("Failed to parse device data: %r", e)
-        return False
 
     async def refresh_data(self):
         """Refresh data from Hatch Rest device."""
@@ -556,38 +607,102 @@ class PyHatchBabyRestAsync:
             )
 
     async def select_favorite(self, index: int):
-        """Select a favorite by index."""
-        command = f"PSB{index:02X}"
+        """Select a favorite by index (confirmed via btsnoop: SP activates, PSB only edits)."""
+        command = f"SP{index:02X}"
         _LOGGER.debug("API command: select_favorite %d", index)
         return await self._send_command(command)
+
+    async def save_to_favorite(self, index: int) -> None:
+        """Save current device state to a favorite slot.
+
+        Protocol confirmed via btsnoop: PSB opens the slot, PSC/PSN/PSV/PSLC0
+        set the fields, PSF commits. PSLC0 purpose is unknown but required.
+        """
+        r, g, b = self.color or (0, 0, 0)
+        brightness = self.brightness or 0
+        sound = (self.sound or PyHatchBabyRestSound.none).value
+        volume = self.volume or 0
+        _LOGGER.debug(
+            "API command: save_to_favorite slot=%d sound=%d vol=%d brightness=%d color=(%d,%d,%d)",
+            index, sound, volume, brightness, r, g, b,
+        )
+        await self._send_commands([
+            f"PSB{index:02X}",
+            f"PSC{r:02X}{g:02X}{b:02X}{brightness:02X}",
+            f"PSN{sound:02X}",
+            f"PSV{volume:02X}",
+            "PSLC0",
+            "PSF",
+        ])
+
+    async def get_timer(self) -> None:
+        """Get the current timer state."""
+        _LOGGER.debug("API command: get_timer (GI)")
+        await self._send_command("GI")
+
+    async def set_timer(self, minutes: int) -> None:
+        """Set a timer for the specified number of minutes."""
+        # SD{hex} — confirmed timer set command
+        command = f"SD{minutes:04X}"
+        _LOGGER.debug("API command: set_timer %s (%d min)", command, minutes)
+        await self._send_command(command)
+
+    async def get_timer_remaining(self) -> None:
+        """Get the remaining time on the current timer."""
+        _LOGGER.debug("API command: get_timer_remaining (GD)")
+        await self._send_command("GD")
+
+    async def toggle_favorite(self, index: int, enable: bool) -> None:
+        """Enable or disable a favorite slot."""
+        # PSL is enable/disable flag: 0xC0 = enabled, 0x80 = disabled
+        # Sequence: PSB{index} -> PSL{flag} -> PSF
+        flag = "C0" if enable else "80"
+        _LOGGER.debug("API command: toggle_favorite slot=%d enable=%s", index, enable)
+        await self._send_commands([
+            f"PSB{index:02X}",
+            f"PSL{flag}",
+            "PSF",
+        ])
+
+    async def toggle_schedule(self, index: int, enable: bool) -> None:
+        """Enable or disable a schedule slot."""
+        # ESL is likely the schedule version of PSL
+        # Sequence: ESB{index} -> ESL{flag} -> ESF
+        flag = "C0" if enable else "80"
+        _LOGGER.debug("API command: toggle_schedule slot=%d enable=%s", index, enable)
+        await self._send_commands([
+            f"ESB{index:02X}",
+            f"ESL{flag}",
+            "ESF",
+        ])
 
     async def turn_power_on(self):
         """Power on the Hatch Rest device."""
         command = f"SI{1:02x}"
         _LOGGER.debug("API command: turn_power_on")
         self.power = True
-        await self._send_command(command)
+        await self._send_command(command, response=False)
 
     async def turn_power_off(self):
         """Power off the Hatch Rest device."""
         command = f"SI{0:02x}"
         _LOGGER.debug("API command: turn_power_off")
         self.power = False
-        await self._send_command(command)
+        await self._send_command(command, response=False)
 
     async def set_sound(self, sound: int):
         """Set the sound of the Hatch Rest device."""
         command = f"SN{sound:02x}"
         _LOGGER.debug("API command: set_sound to %s", command)
         self.sound = PyHatchBabyRestSound(sound)
-        return await self._send_command(command)
+        return await self._send_command(command, response=False)
 
     async def set_volume(self, volume: int):
         """Set the volume of the Hatch Rest device."""
         command = f"SV{volume:02x}"
         _LOGGER.debug("API command: set_volume to %s", command)
         self.volume = volume
-        return await self._send_command(command)
+        return await self._send_command(command, response=False)
 
     async def set_color(self, red: int, green: int, blue: int):
         """Set the color of the Hatch Rest device."""
@@ -611,7 +726,7 @@ class PyHatchBabyRestAsync:
         if self.color is not None and self.brightness is not None:
             command = f"SC{self.color[0]:02x}{self.color[1]:02x}{self.color[2]:02x}{self.brightness:02x}"
             _LOGGER.debug("API command: set_light_state to %s", command)
-            return await self._send_command(command)
+            return await self._send_command(command, response=False)
         return None
 
     @property

--- a/custom_components/hatch_rest/api.py
+++ b/custom_components/hatch_rest/api.py
@@ -10,6 +10,7 @@ from collections.abc import Callable
 import asyncio
 from datetime import datetime
 import logging
+import struct
 from time import monotonic
 
 from bleak.backends.device import BLEDevice
@@ -22,14 +23,9 @@ from bleak_retry_connector import (
     establish_connection,
 )
 
-from .const import CHAR_FEEDBACK, CHAR_TX, PyHatchBabyRestSound
+from .const import CHAR_FEEDBACK, CHAR_LIST, CHAR_TX, PyHatchBabyRestSound
 
 _LOGGER = logging.getLogger(__name__)
-
-
-def _assert_value(check_val: list[str], index: int, assert_val: str):
-    if check_val[index] != assert_val:
-        raise ValueError(f'response[{index}] "{check_val[index]}" != "{assert_val}"')
 
 
 class PyHatchBabyRestAsync:
@@ -56,6 +52,15 @@ class PyHatchBabyRestAsync:
         self.sound: PyHatchBabyRestSound | None = None
         self.volume: int | None = None
         self.power: bool | None = None
+        
+        self.favorites: dict[int, dict] = {}
+        self.active_favorite: int | None = None
+        self.schedules: dict[int, dict] = {}
+        self._last_index_seen: int | None = None
+        self._pending_slot: dict = {}  # buffered data before first index arrives
+        self._pgb_slot: int | None = None  # slot index of in-flight PGB (favorite) request
+        self._egb_slot: int | None = None  # slot index of in-flight EGB (schedule) request
+        self._last_full_fetch: float | None = None  # monotonic time of last PGB+EGB sweep
 
     def update_ble_device(self, ble_device: BLEDevice) -> None:
         """Update the BLE device."""
@@ -76,7 +81,8 @@ class PyHatchBabyRestAsync:
         self.update_ble_device(service_info.device)
 
         # Parse the advertisement data (it uses the same tagged format)
-        self._parse_data(data)
+        if self._parse_data(data):
+            self._notify_callbacks()
 
     def register_callback(self, callback: Callable[[], None]) -> None:
         """Register a callback for when data is updated."""
@@ -118,22 +124,12 @@ class PyHatchBabyRestAsync:
 
         async with self._connection_cv:
             if self._client and self._client.is_connected:
-                _LOGGER.debug(
-                    "self._client = %s and and self._client.is_connected = %s -- using existing connection",
-                    self._client,
-                    self._client.is_connected,
-                )
                 return
 
             if self._connecting:
-                _LOGGER.debug(
-                    "self._connecting = %s -- wait for connection to establish",
-                    self._connecting,
-                )
                 await self._connection_cv.wait()
                 return
 
-            _LOGGER.debug("No existing connection -- setting self._connecting = True")
             self._connecting = True
 
         try:
@@ -145,23 +141,60 @@ class PyHatchBabyRestAsync:
             )
             _LOGGER.debug("Client connected: %s", client.is_connected)
 
-            # Start notifications if supported
-            if client.is_connected and not self._is_notifying:
-                try:
-                    _LOGGER.debug("Starting notifications on %s", CHAR_FEEDBACK)
-                    await client.start_notify(CHAR_FEEDBACK, self._notification_handler)
-                    self._is_notifying = True
-                except Exception as e:
-                    _LOGGER.warning("Could not start notifications: %r", e)
+            # Reset per-connection parse state
+            self._last_index_seen = None
+            self._pending_slot = {}
+            self._pgb_slot = None
+            self._egb_slot = None
 
-        except (
-            BleakNotFoundError,
-            BleakOutOfConnectionSlotsError,
-            BleakAbortedError,
-            BleakConnectionError,
-            Exception,  # noqa: BLE001
-        ) as e:
-            _LOGGER.warning("Exception during _client_connect -- %r", e)
+            # Start notifications
+            if client.is_connected:
+                try:
+                    # We subscribe to the CONFIG channel FIRST to ensure we don't miss the dump
+                    _LOGGER.debug("Subscribing to config channel %s...", CHAR_LIST)
+                    await client.start_notify(CHAR_LIST, self._notification_handler)
+                    
+                    _LOGGER.debug("Subscribing to feedback channel %s...", CHAR_FEEDBACK)
+                    await client.start_notify(CHAR_FEEDBACK, self._notification_handler)
+                    
+                    self._is_notifying = True
+                    # GF returns the active favorite index. Then PGB01-PGB06
+                    # fetches each slot's config+name. Both confirmed via btsnoop.
+                    _LOGGER.debug("Requesting active favorite index via 'GF'")
+                    await client.write_gatt_char(
+                        CHAR_TX, bytearray(b"GF"), response=False
+                    )
+                    fetch_age = monotonic() - self._last_full_fetch if self._last_full_fetch else None
+                    if fetch_age is None or fetch_age > 3600:
+                        _LOGGER.debug("Fetching favorites and schedules (age=%s)", fetch_age)
+                        self.favorites = {}
+                        self.schedules = {}
+
+                        for slot in range(1, 7):
+                            self._pgb_slot = slot
+                            cmd = f"PGB{slot:02X}".encode()
+                            _LOGGER.debug("Requesting favorite slot '%s'", cmd.decode())
+                            await client.write_gatt_char(CHAR_TX, bytearray(cmd), response=False)
+                            await asyncio.sleep(0.15)
+                        self._pgb_slot = None
+
+                        for slot in range(1, 11):
+                            self._egb_slot = slot
+                            cmd = f"EGB{slot:02X}".encode()
+                            _LOGGER.debug("Requesting schedule slot '%s'", cmd.decode())
+                            await client.write_gatt_char(CHAR_TX, bytearray(cmd), response=False)
+                            await asyncio.sleep(0.15)
+                        self._egb_slot = None
+
+                        self._last_full_fetch = monotonic()
+                    else:
+                        _LOGGER.debug("Skipping favorites/schedules fetch (age=%.0fs)", fetch_age)
+                except Exception as e:
+                    if "already notifying" not in str(e):
+                        _LOGGER.warning("Notification error: %r", e)
+
+        except Exception as e:
+            _LOGGER.warning("Connect error: %r", e)
             client = None
 
         async with self._connection_cv:
@@ -187,7 +220,7 @@ class PyHatchBabyRestAsync:
 
         if self._client and self._active_operations == 0:
             _LOGGER.debug(
-                "self._client = %s and self._running_tasks = %d, attempting to disconnect",
+                "self._client = %s and self._active_operations = %d, attempting to disconnect",
                 self._client,
                 self._active_operations,
             )
@@ -204,15 +237,16 @@ class PyHatchBabyRestAsync:
                 _LOGGER.warning("Exception during _client_disconnect -- %r", e)
         else:
             _LOGGER.debug(
-                "self._client = %s and self._running_tasks = %d, cannot currently disconnect",
+                "self._client = %s and self._active_operations = %d, cannot currently disconnect",
                 self._client,
                 self._active_operations,
             )
 
-    async def _send_command(self, command: str):
-        """Send a command do the device.
+    async def _send_command(self, command: str, raw: bool = False):
+        """Send a command to the device.
 
-        :param command: The command to send.
+        :param command: ASCII command string, or hex-encoded bytes if raw=True.
+        :param raw: If True, decode command as hex string and send raw bytes.
         """
         if log_timing := _LOGGER.isEnabledFor(logging.DEBUG):
             start = monotonic()
@@ -223,10 +257,12 @@ class PyHatchBabyRestAsync:
 
         try:
             if self._client and self._client.is_connected:
+                data = bytearray.fromhex(command) if raw else bytearray(command, "utf-8")
+                _LOGGER.debug("Sending command '%s' (Hex: %s)", command, data.hex())
                 await self._client.write_gatt_char(
                     char_specifier=CHAR_TX,
-                    data=bytearray(command, "utf-8"),
-                    response=True,
+                    data=data,
+                    response=False,
                 )
             else:
                 _LOGGER.warning("Could not send command: Not connected to device")
@@ -250,14 +286,183 @@ class PyHatchBabyRestAsync:
                 monotonic() - start,  # pyright: ignore[reportPossiblyUnboundVariable]
             )
 
-    def _notification_handler(self, characteristic: int, data: bytearray) -> None:
+    def _notification_handler(self, char_specifier, data: bytearray) -> None:
         """Handle incoming notifications from the device."""
-        # _parse_data already handles the logic and "CHANGED" logging
-        self._parse_data(data)
-        self._notify_callbacks()
+        # char_specifier can be a BleakGATTCharacteristic (has .uuid) or an int handle
+        char_uuid = getattr(char_specifier, "uuid", None)
+        handle = char_specifier if isinstance(char_specifier, int) else getattr(char_specifier, "handle", None)
+        
+        _LOGGER.debug("[Notification] Handle: %s, UUID: %s, Data: %s", handle, char_uuid, data.hex())
+        
+        # Identify the source. 02240003 is often handle 19, 02260002 is handle 23.
+        # We check UUID string first, then fallback to logic based on characteristic type
+        is_config = False
+        if char_uuid == CHAR_LIST:
+            is_config = True
+        elif isinstance(char_specifier, int) or char_uuid is None:
+            # Fallback for handle-only notifications: config packets usually 
+            # don't start with 'Ti' (0x54 0x69)
+            if not data.startswith(b"Ti"):
+                is_config = True
 
-    def _parse_data(self, data: bytearray) -> None:
-        """Parse raw device data and update state using markers."""
+        if is_config:
+            self._parse_config_data(data)
+            self._notify_callbacks()
+        elif self._parse_data(data):
+            self._notify_callbacks()
+
+    @staticmethod
+    def _decode_config_block(data: bytearray) -> dict:
+        """Decode a 15-byte PGB favorite block.
+
+        Layout: [0x01] [sound] [volume] [00x6] [brightness] [B] [G] [R] [flags] [0x03]
+        """
+        sound_id = data[1]
+        volume = data[2]
+        brightness = data[9]
+        blue, green, red = data[10], data[11], data[12]
+        try:
+            sound = PyHatchBabyRestSound(sound_id)
+        except ValueError:
+            sound = sound_id
+        return {
+            "sound": sound,
+            "volume": volume,
+            "brightness": brightness,
+            "color": (red, green, blue),
+            "raw": data.hex(),
+        }
+
+    @staticmethod
+    def _decode_schedule_block(data: bytearray) -> dict:
+        """Decode a 20-byte EGB schedule block.
+
+        Layout (confirmed via live EGB responses):
+          [0x01] [unix_ts LE x4] [sound] [volume] [hour] [minute]
+          [00x4] [brightness] [B] [G] [R] [0x00] [days_bitmask] [flags]
+
+        days_bitmask bits 1-5 = Mon-Fri (0x3e = Mon-Fri confirmed).
+        """
+        sound_id = data[5]
+        volume = data[6]
+        hour = data[7]
+        minute = data[8]
+        brightness = data[13]
+        blue, green, red = data[14], data[15], data[16]
+        days_mask = data[18] if len(data) > 18 else 0
+        modified_ts = struct.unpack_from("<I", data, 1)[0]
+        days = {
+            "mon": bool(days_mask & 0x02),
+            "tue": bool(days_mask & 0x04),
+            "wed": bool(days_mask & 0x08),
+            "thu": bool(days_mask & 0x10),
+            "fri": bool(days_mask & 0x20),
+            "sat": bool(days_mask & 0x40),
+            "sun": bool(days_mask & 0x01),
+        }
+        try:
+            sound = PyHatchBabyRestSound(sound_id)
+        except ValueError:
+            sound = sound_id
+        return {
+            "sound": sound,
+            "volume": volume,
+            "hour": hour,
+            "minute": minute,
+            "brightness": brightness,
+            "color": (red, green, blue),
+            "days": days,
+            "modified_ts": modified_ts,
+            "raw": data.hex(),
+        }
+
+    def _flush_pending_slot(self, index: int) -> None:
+        """Merge buffered config/name (received before first index) into favorites."""
+        if self._pending_slot:
+            _LOGGER.debug("Flushing pending slot data to index %d: %s", index, self._pending_slot)
+            self.favorites.setdefault(index, {}).update(self._pending_slot)
+            self._pending_slot = {}
+
+    def _parse_config_data(self, data: bytearray) -> None:
+        """Parse configuration data (names, indices, etc) from CHAR_LIST."""
+        if not data:
+            return
+
+        _LOGGER.debug("[Config] Hex: %s | ASCII: %s", data.hex(), data.decode("utf-8", errors="ignore"))
+
+        try:
+            header = data[0]
+            
+            # Header 0x30 is an Index block (ASCII "0", followed by index "1", "2"...)
+            if header == 0x30 and len(data) >= 2:
+                index_str = data[1:2].decode("utf-8", errors="ignore")
+                if index_str.isdigit():
+                    index = int(index_str)
+                    _LOGGER.debug("Active index (0x30): %d", index)
+                    self.active_favorite = index
+                    self._last_index_seen = index
+                    self._flush_pending_slot(index)
+
+            # Header 0x45 ('E') is another Index block
+            elif header == 0x45 and len(data) >= 3:
+                index_str = data[1:3].decode("utf-8", errors="ignore")
+                if index_str.isdigit():
+                    index = int(index_str)
+                    _LOGGER.debug("Active index (0x45): %d", index)
+                    self.active_favorite = index
+                    self._last_index_seen = index
+                    self._flush_pending_slot(index)
+
+            # Header 0x07 is an ASCII name block
+            elif header == 0x07:
+                # Some packets have a leading null or control byte before the text
+                start_idx = 1
+                while start_idx < len(data) and data[start_idx] < 32:
+                    start_idx += 1
+
+                name_bytes = data[start_idx:]
+                if 0x00 in name_bytes:
+                    name_bytes = name_bytes[:name_bytes.find(0x00)]
+
+                name = name_bytes.decode("utf-8", errors="ignore").strip()
+                if name:
+                    if self._egb_slot is not None:
+                        _LOGGER.debug("Schedule name '%s' (slot %d)", name, self._egb_slot)
+                        self.schedules.setdefault(self._egb_slot, {})["name"] = name
+                    elif self._last_index_seen is None:
+                        _LOGGER.debug("Buffering name '%s' (index not yet known)", name)
+                        self._pending_slot["name"] = name
+                    else:
+                        _LOGGER.debug("Captured name '%s' (index %d)", name, self._last_index_seen)
+                        self.schedules.setdefault(self._last_index_seen, {})["name"] = name
+
+            # Header 0x01 — 15-byte = favorite (PGB), 20-byte = schedule (EGB)
+            elif header == 0x01 and len(data) >= 13:
+                if len(data) >= 20:
+                    parsed = self._decode_schedule_block(data)
+                    idx = self._egb_slot or self._last_index_seen
+                    _LOGGER.debug("Schedule config slot %s: %s", idx, parsed)
+                    if idx is not None:
+                        self.schedules.setdefault(idx, {}).update(parsed)
+                else:
+                    parsed = self._decode_config_block(data)
+                    _LOGGER.debug("Favorite config slot %s: %s", self._pgb_slot, parsed)
+                    idx = self._pgb_slot or self._last_index_seen
+                    if idx is None:
+                        self._pending_slot.update(parsed)
+                    else:
+                        self.favorites.setdefault(idx, {}).update(parsed)
+
+            # Header 0x4F ('OK')
+            elif data.startswith(b"OK"):
+                _LOGGER.debug("Device acknowledged command (OK)")
+
+        except Exception as e:
+            _LOGGER.debug("Failed to parse config notification: %r", e)
+
+    def _parse_data(self, data: bytearray) -> bool:
+        """Parse raw device data and update state. Returns True if state changed."""
+        _LOGGER.debug("Parsing raw data: %s", data.hex())
         try:
             # Find Color Section 'C' (0x43)
             c_idx = data.find(0x43)
@@ -272,7 +477,12 @@ class PyHatchBabyRestAsync:
             # Find Sound Section 'S' (0x53)
             s_idx = data.find(0x53)
             if s_idx != -1 and len(data) >= s_idx + 3:
-                new_sound = PyHatchBabyRestSound(data[s_idx + 1])
+                sound_id = data[s_idx + 1]
+                try:
+                    new_sound = PyHatchBabyRestSound(sound_id)
+                except ValueError:
+                    _LOGGER.debug("Unknown sound ID received: %d", sound_id)
+                    new_sound = self.sound # Keep current if unknown
                 new_volume = data[s_idx + 2]
             else:
                 new_sound = self.sound
@@ -285,7 +495,6 @@ class PyHatchBabyRestAsync:
             else:
                 new_power = self.power
 
-            # Check if anything has actually changed
             if (
                 new_color == self.color
                 and new_brightness == self.brightness
@@ -293,7 +502,7 @@ class PyHatchBabyRestAsync:
                 and new_volume == self.volume
                 and new_power == self.power
             ):
-                return
+                return False
 
             self.color = new_color
             self.brightness = new_brightness
@@ -303,15 +512,12 @@ class PyHatchBabyRestAsync:
 
             _LOGGER.debug(
                 "Parsed state (CHANGED): power=%s, brightness=%s, color=%s, sound=%s, volume=%s",
-                self.power,
-                self.brightness,
-                self.color,
-                self.sound,
-                self.volume,
+                self.power, self.brightness, self.color, self.sound, self.volume,
             )
-            self._notify_callbacks()
+            return True
         except (ValueError, IndexError) as e:
             _LOGGER.warning("Failed to parse device data: %r", e)
+        return False
 
     async def refresh_data(self):
         """Refresh data from Hatch Rest device."""
@@ -349,6 +555,11 @@ class PyHatchBabyRestAsync:
                 monotonic() - start,  # pyright: ignore[reportPossiblyUnboundVariable]
             )
 
+    async def select_favorite(self, index: int):
+        """Select a favorite by index."""
+        command = f"PSB{index:02X}"
+        _LOGGER.debug("API command: select_favorite %d", index)
+        return await self._send_command(command)
 
     async def turn_power_on(self):
         """Power on the Hatch Rest device."""

--- a/custom_components/hatch_rest/api.py
+++ b/custom_components/hatch_rest/api.py
@@ -72,10 +72,11 @@ class PyHatchBabyRestAsync:
         data = service_info.manufacturer_data[MANUFACTURER_ID]
         _LOGGER.debug("Received advertisement data: %s", data.hex())
 
-        # The advertisement data format for Hatch Rest varies, but some versions
-        # include status bytes. If yours does, we can parse it here.
-        # For now, we update the BLEDevice so the next connection is faster.
+        # Update the BLEDevice so the next connection is faster
         self.update_ble_device(service_info.device)
+
+        # Parse the advertisement data (it uses the same tagged format)
+        self._parse_data(data)
 
     def register_callback(self, callback: Callable[[], None]) -> None:
         """Register a callback for when data is updated."""
@@ -256,38 +257,49 @@ class PyHatchBabyRestAsync:
         self._notify_callbacks()
 
     def _parse_data(self, data: bytearray) -> None:
-        """Parse raw device data and update state."""
-        response = [hex(x) for x in data]
-
-        # Make sure the data is where we think it is
+        """Parse raw device data and update state using markers."""
         try:
-            _assert_value(response, 5, "0x43")  # color
-            _assert_value(response, 10, "0x53")  # audio
-            _assert_value(response, 13, "0x50")  # power
+            # Find Color Section 'C' (0x43)
+            c_idx = data.find(0x43)
+            if c_idx != -1 and len(data) >= c_idx + 5:
+                red, green, blue, brightness = data[c_idx + 1 : c_idx + 5]
+                new_color = (red, green, blue)
+                new_brightness = brightness
+            else:
+                new_color = self.color
+                new_brightness = self.brightness
 
-            red, green, blue, brightness = [int(x, 16) for x in response[6:10]]
-            sound = PyHatchBabyRestSound(int(response[11], 16))
-            volume = int(response[12], 16)
-            power = not bool(int("11000000", 2) & int(response[14], 16))
+            # Find Sound Section 'S' (0x53)
+            s_idx = data.find(0x53)
+            if s_idx != -1 and len(data) >= s_idx + 3:
+                new_sound = PyHatchBabyRestSound(data[s_idx + 1])
+                new_volume = data[s_idx + 2]
+            else:
+                new_sound = self.sound
+                new_volume = self.volume
 
-            new_color = (red, green, blue)
+            # Find Power Section 'P' (0x50)
+            p_idx = data.find(0x50)
+            if p_idx != -1 and len(data) >= p_idx + 2:
+                new_power = not bool(int("11000000", 2) & data[p_idx + 1])
+            else:
+                new_power = self.power
 
             # Check if anything has actually changed
             if (
                 new_color == self.color
-                and brightness == self.brightness
-                and sound == self.sound
-                and volume == self.volume
-                and power == self.power
+                and new_brightness == self.brightness
+                and new_sound == self.sound
+                and new_volume == self.volume
+                and new_power == self.power
             ):
-                _LOGGER.debug("State unchanged, skipping callback")
                 return
 
             self.color = new_color
-            self.brightness = brightness
-            self.sound = sound
-            self.volume = volume
-            self.power = power
+            self.brightness = new_brightness
+            self.sound = new_sound
+            self.volume = new_volume
+            self.power = new_power
 
             _LOGGER.debug(
                 "Parsed state (CHANGED): power=%s, brightness=%s, color=%s, sound=%s, volume=%s",

--- a/custom_components/hatch_rest/api.py
+++ b/custom_components/hatch_rest/api.py
@@ -45,6 +45,7 @@ class PyHatchBabyRestAsync:
         # connection synchronization primitizes / state
         self._connection_cv = asyncio.Condition()
         self._connecting: bool = False
+        self._disconnect_timer: asyncio.TimerHandle | None = None
 
         # cached device state
         self.color: tuple[int, int, int] | None = None
@@ -67,9 +68,16 @@ class PyHatchBabyRestAsync:
         """Callback for when the client disconnects."""
         _LOGGER.debug("API client has successfully disconnected")
         self._client = None
+        if self._disconnect_timer:
+            self._disconnect_timer.cancel()
+            self._disconnect_timer = None
 
     async def _client_connect(self) -> None:
         """Connect to the device."""
+        if self._disconnect_timer:
+            self._disconnect_timer.cancel()
+            self._disconnect_timer = None
+
         async with self._connection_cv:
             if self._client and self._client.is_connected:
                 _LOGGER.debug(
@@ -114,13 +122,25 @@ class PyHatchBabyRestAsync:
             self._client = client
             self._connection_cv.notify_all()
 
+    def _schedule_disconnect(self) -> None:
+        """Schedule a disconnection after a cooldown period."""
+        if self._disconnect_timer:
+            self._disconnect_timer.cancel()
+
+        self._disconnect_timer = asyncio.get_event_loop().call_later(
+            10, lambda: asyncio.create_task(self._client_disconnect())
+        )
+        _LOGGER.debug("Scheduled disconnect in 10 seconds")
+
     async def _client_disconnect(self) -> None:
         """Disconnect from the device."""
+        if self._disconnect_timer:
+            self._disconnect_timer.cancel()
+            self._disconnect_timer = None
+
         if self._client and self._active_operations == 0:
-            # if self._client:
             _LOGGER.debug(
                 "self._client = %s and self._running_tasks = %d, attempting to disconnect",
-                # "self._client = %s, attempting to disconnect",
                 self._client,
                 self._active_operations,
             )
@@ -138,7 +158,6 @@ class PyHatchBabyRestAsync:
         else:
             _LOGGER.debug(
                 "self._client = %s and self._running_tasks = %d, cannot currently disconnect",
-                # "self._client = %s, cannot currently disconnect",
                 self._client,
                 self._active_operations,
             )
@@ -172,9 +191,7 @@ class PyHatchBabyRestAsync:
             _LOGGER.warning("Exception during _send_command -- %r", e)
 
         self._set_active_operations(-1)
-        # seemingly need some time for Hatch Rest to "catch up"
-        await asyncio.sleep(1)
-        await self.refresh_data()
+        self._schedule_disconnect()
 
         if log_timing:
             _LOGGER.debug(
@@ -231,7 +248,7 @@ class PyHatchBabyRestAsync:
             _LOGGER.warning("Exception during refresh_data -- %r", e)
 
         self._set_active_operations(-1)
-        await self._client_disconnect()
+        self._schedule_disconnect()
 
         if log_timing:
             _LOGGER.debug(
@@ -244,38 +261,54 @@ class PyHatchBabyRestAsync:
         """Power on the Hatch Rest device."""
         command = f"SI{1:02x}"
         _LOGGER.debug("API command: turn_power_on")
+        self.power = True
         await self._send_command(command)
 
     async def turn_power_off(self):
         """Power off the Hatch Rest device."""
         command = f"SI{0:02x}"
         _LOGGER.debug("API command: turn_power_off")
+        self.power = False
         await self._send_command(command)
 
     async def set_sound(self, sound: int):
         """Set the sound of the Hatch Rest device."""
         command = f"SN{sound:02x}"
         _LOGGER.debug("API command: set_sound to %s", command)
+        self.sound = PyHatchBabyRestSound(sound)
         return await self._send_command(command)
 
     async def set_volume(self, volume: int):
         """Set the volume of the Hatch Rest device."""
         command = f"SV{volume:02x}"
         _LOGGER.debug("API command: set_volume to %s", command)
+        self.volume = volume
         return await self._send_command(command)
 
     async def set_color(self, red: int, green: int, blue: int):
         """Set the color of the Hatch Rest device."""
-        command = f"SC{red:02x}{green:02x}{blue:02x}{self.brightness:02x}"
-        _LOGGER.debug("API command: set_color to %s", command)
-        return await self._send_command(command)
+        return await self.set_light_state(color=(red, green, blue))
 
     async def set_brightness(self, brightness: int):
         """Set the brightness of the Hatch Rest device."""
-        if self.color:
-            command = f"SC{self.color[0]:02x}{self.color[1]:02x}{self.color[2]:02x}{brightness:02x}"
-        _LOGGER.debug("API command: set_brightness to %s", command)
-        return await self._send_command(command)
+        return await self.set_light_state(brightness=brightness)
+
+    async def set_light_state(
+        self,
+        brightness: int | None = None,
+        color: tuple[int, int, int] | None = None,
+    ):
+        """Set the light state (color and brightness) in one command."""
+        if brightness is not None:
+            self.brightness = brightness
+        if color is not None:
+            self.color = color
+
+        if self.color is not None and self.brightness is not None:
+            command = f"SC{self.color[0]:02x}{self.color[1]:02x}{self.color[2]:02x}{self.brightness:02x}"
+            _LOGGER.debug("API command: set_light_state to %s", command)
+            return await self._send_command(command)
+        return None
 
     @property
     def name(self):

--- a/custom_components/hatch_rest/api.py
+++ b/custom_components/hatch_rest/api.py
@@ -8,6 +8,7 @@ https://github.com/kjoconnor/pyhatchbabyrest/blob/master/LICENSE
 
 from collections import deque
 from collections.abc import Callable
+from contextlib import asynccontextmanager
 import asyncio
 from datetime import datetime
 import logging
@@ -16,17 +17,32 @@ from time import monotonic
 
 from bleak.backends.device import BLEDevice
 from bleak_retry_connector import (
-    BleakAbortedError,
     BleakClientWithServiceCache,
     BleakConnectionError,
-    BleakNotFoundError,
-    BleakOutOfConnectionSlotsError,
     establish_connection,
 )
 
 from .const import CHAR_FEEDBACK, CHAR_LIST, CHAR_TX, PyHatchBabyRestSound
 
 _LOGGER = logging.getLogger(__name__)
+
+
+class _SlotFetch:
+    """Pairs a slot index with an asyncio.Event so the fetch loop can await the notification."""
+
+    def __init__(self, slot: int) -> None:
+        self.slot = slot
+        self._event = asyncio.Event()
+
+    def complete(self) -> None:
+        self._event.set()
+
+    async def wait(self, timeout: float = 1.0) -> bool:
+        try:
+            await asyncio.wait_for(self._event.wait(), timeout=timeout)
+            return True
+        except asyncio.TimeoutError:
+            return False
 
 
 class PyHatchBabyRestAsync:
@@ -92,8 +108,8 @@ class PyHatchBabyRestAsync:
         self.schedules: dict[int, dict] = {}
         self._last_index_seen: int | None = None
         self._pending_slot: dict = {}  # buffered data before first index arrives
-        self._pgb_slot: int | None = None  # slot index of in-flight PGB during initial fetch
-        self._egb_slot: int | None = None  # slot index of in-flight EGB during initial fetch
+        self._pgb_fetch: _SlotFetch | None = None  # in-flight PGB fetch during initial sweep
+        self._egb_fetch: _SlotFetch | None = None  # in-flight EGB fetch during initial sweep
         self._pending_pgb_slots: deque[int] = deque()  # slots queued from toggle_favorite
         self._pending_egb_slots: deque[int] = deque()  # slots queued from toggle_schedule
         self._last_full_fetch: float | None = None  # monotonic time of last PGB+EGB sweep
@@ -133,15 +149,20 @@ class PyHatchBabyRestAsync:
         for callback in self._callbacks:
             callback()
 
-    def _set_active_operations(self, amount: int):
-        """Change the number of running tasks."""
-        if amount > 0:
-            _LOGGER.debug("Incrementing self._active_operations by %d", amount)
-            self._active_operations += 1
-        if amount < 0:
-            _LOGGER.debug("Decrementing self._active_operations by %d", abs(amount))
+    @asynccontextmanager
+    async def _active_operation(self):
+        """Context manager that tracks an in-flight operation and schedules disconnect on exit."""
+        self._active_operations += 1
+        _LOGGER.debug("Active operations: %d", self._active_operations)
+        await self._client_connect()
+        try:
+            yield self._client
+        except Exception as e:
+            _LOGGER.warning("Operation error: %r", e)
+        finally:
             self._active_operations -= 1
-        _LOGGER.debug("self._active_operations = %d", self._active_operations)
+            _LOGGER.debug("Active operations: %d", self._active_operations)
+            self._schedule_disconnect()
 
     def _client_disconnected(self, client: BleakClientWithServiceCache) -> None:
         """Callback for when the client disconnects."""
@@ -151,6 +172,28 @@ class PyHatchBabyRestAsync:
         if self._disconnect_timer:
             self._disconnect_timer.cancel()
             self._disconnect_timer = None
+
+    async def _fetch_favorites(self, client: BleakClientWithServiceCache) -> None:
+        """Fetch all 6 favorite slots, waiting for each PGB notification before continuing."""
+        for slot in range(1, 7):
+            self._pgb_fetch = _SlotFetch(slot)
+            cmd = f"PGB{slot:02X}"
+            _LOGGER.debug("Requesting %s", cmd)
+            await client.write_gatt_char(CHAR_TX, bytearray(cmd, "utf-8"), response=False)
+            if not await self._pgb_fetch.wait():
+                _LOGGER.warning("Timeout waiting for %s response", cmd)
+        self._pgb_fetch = None
+
+    async def _fetch_schedules(self, client: BleakClientWithServiceCache) -> None:
+        """Fetch all 10 schedule slots, waiting for each EGB notification before continuing."""
+        for slot in range(1, 11):
+            self._egb_fetch = _SlotFetch(slot)
+            cmd = f"EGB{slot:02X}"
+            _LOGGER.debug("Requesting %s", cmd)
+            await client.write_gatt_char(CHAR_TX, bytearray(cmd, "utf-8"), response=False)
+            if not await self._egb_fetch.wait():
+                _LOGGER.warning("Timeout waiting for %s response", cmd)
+        self._egb_fetch = None
 
     async def _client_connect(self) -> None:
         """Connect to the device."""
@@ -180,8 +223,8 @@ class PyHatchBabyRestAsync:
             # Reset per-connection parse state
             self._last_index_seen = None
             self._pending_slot = {}
-            self._pgb_slot = None
-            self._egb_slot = None
+            self._pgb_fetch = None
+            self._egb_fetch = None
             self._pending_pgb_slots.clear()
             self._pending_egb_slots.clear()
 
@@ -216,24 +259,11 @@ class PyHatchBabyRestAsync:
                     fetch_age = monotonic() - self._last_full_fetch if self._last_full_fetch else None
                     if fetch_age is None or fetch_age > self.full_refresh_interval:
                         _LOGGER.debug("Fetching favorites and schedules (age=%s)", fetch_age)
-                        self.favorites = {}
-                        self.schedules = {}
+                        # Update in-place — don't clear, so toggle_favorite can still read
+                        # existing cache while the fresh PGB/EGB responses arrive.
 
-                        for slot in range(1, 7):
-                            self._pgb_slot = slot
-                            cmd = f"PGB{slot:02X}".encode()
-                            _LOGGER.debug("Requesting favorite slot '%s'", cmd.decode())
-                            await client.write_gatt_char(CHAR_TX, bytearray(cmd), response=False)
-                            await asyncio.sleep(0.15)
-                        self._pgb_slot = None
-
-                        for slot in range(1, 11):
-                            self._egb_slot = slot
-                            cmd = f"EGB{slot:02X}".encode()
-                            _LOGGER.debug("Requesting schedule slot '%s'", cmd.decode())
-                            await client.write_gatt_char(CHAR_TX, bytearray(cmd), response=False)
-                            await asyncio.sleep(0.15)
-                        self._egb_slot = None
+                        await self._fetch_favorites(client)
+                        await self._fetch_schedules(client)
 
                         self._last_full_fetch = monotonic()
                     else:
@@ -275,14 +305,7 @@ class PyHatchBabyRestAsync:
             )
             try:
                 await self._client.disconnect()
-
-            except (
-                BleakNotFoundError,
-                BleakOutOfConnectionSlotsError,
-                BleakAbortedError,
-                BleakConnectionError,
-                Exception,  # noqa: BLE001
-            ) as e:
+            except Exception as e:  # noqa: BLE001
                 _LOGGER.warning("Exception during _client_disconnect -- %r", e)
         else:
             _LOGGER.debug(
@@ -312,50 +335,24 @@ class PyHatchBabyRestAsync:
         async with self._send_lock:
             if log_timing := _LOGGER.isEnabledFor(logging.DEBUG):
                 start = monotonic()
-                _LOGGER.debug(
-                    "Started batch _send_commands at %s", datetime.now().isoformat()
-                )
+                _LOGGER.debug("Started batch _send_commands at %s", datetime.now().isoformat())
 
-            self._set_active_operations(1)
-            await self._client_connect()
+            async with self._active_operation() as client:
+                # Enqueue response slots AFTER connecting — connect resets the deques on reconnect.
+                if pgb_slot is not None:
+                    self._pending_pgb_slots.append(pgb_slot)
+                if egb_slot is not None:
+                    self._pending_egb_slots.append(egb_slot)
 
-            # Register expected response slots AFTER connecting — _client_connect may clear
-            # the deques when reconnecting, so we enqueue only once the connection is stable.
-            if pgb_slot is not None:
-                self._pending_pgb_slots.append(pgb_slot)
-            if egb_slot is not None:
-                self._pending_egb_slots.append(egb_slot)
-
-            try:
-                if self._client and self._client.is_connected:
+                if client and client.is_connected:
                     for i, command in enumerate(commands):
-                        data = (
-                            bytearray.fromhex(command)
-                            if raw
-                            else bytearray(command, "utf-8")
-                        )
+                        data = bytearray.fromhex(command) if raw else bytearray(command, "utf-8")
                         _LOGGER.debug("Sending command '%s' (Hex: %s)", command, data.hex())
-                        await self._client.write_gatt_char(
-                            char_specifier=CHAR_TX,
-                            data=data,
-                            response=response,
-                        )
+                        await client.write_gatt_char(char_specifier=CHAR_TX, data=data, response=response)
                         if i < len(commands) - 1 and spacing_delay > 0:
                             await asyncio.sleep(spacing_delay)
                 else:
                     _LOGGER.warning("Could not send commands: Not connected to device")
-
-            except (
-                BleakNotFoundError,
-                BleakOutOfConnectionSlotsError,
-                BleakAbortedError,
-                BleakConnectionError,
-                Exception,  # noqa: BLE001
-            ) as e:
-                _LOGGER.warning("Exception during _send_commands -- %r", e)
-
-            self._set_active_operations(-1)
-            self._schedule_disconnect()
 
             if log_timing:
                 _LOGGER.debug(
@@ -528,10 +525,10 @@ class PyHatchBabyRestAsync:
 
                 name = name_bytes.decode("utf-8", errors="ignore").strip()
                 if name:
-                    if self._egb_slot is not None:
-                        slot_dict = self.schedules.setdefault(self._egb_slot, {})
+                    if self._egb_fetch is not None:
+                        slot_dict = self.schedules.setdefault(self._egb_fetch.slot, {})
                         if slot_dict.get("name") != name:
-                            _LOGGER.debug("Schedule name '%s' (slot %d)", name, self._egb_slot)
+                            _LOGGER.debug("Schedule name '%s' (slot %d)", name, self._egb_fetch.slot)
                             slot_dict["name"] = name
                             changed = True
                     elif self._last_index_seen is None:
@@ -552,19 +549,21 @@ class PyHatchBabyRestAsync:
                     if self._pending_egb_slots:
                         idx = self._pending_egb_slots.popleft()
                     else:
-                        idx = self._egb_slot or self._last_index_seen
+                        idx = self._egb_fetch.slot if self._egb_fetch else self._last_index_seen
                     if idx is not None:
                         slot_dict = self.schedules.setdefault(idx, {})
                         if any(slot_dict.get(k) != v for k, v in parsed.items()):
                             _LOGGER.debug("Schedule config slot %s: %s", idx, parsed)
                             slot_dict.update(parsed)
                             changed = True
+                    if self._egb_fetch is not None:
+                        self._egb_fetch.complete()
                 else:
                     parsed = self._decode_config_block(data)
                     if self._pending_pgb_slots:
                         idx = self._pending_pgb_slots.popleft()
                     else:
-                        idx = self._pgb_slot or self._last_index_seen
+                        idx = self._pgb_fetch.slot if self._pgb_fetch else self._last_index_seen
                     if idx is None:
                         if any(self._pending_slot.get(k) != v for k, v in parsed.items()):
                             self._pending_slot.update(parsed)
@@ -574,6 +573,8 @@ class PyHatchBabyRestAsync:
                             _LOGGER.debug("Favorite config slot %s: %s", idx, parsed)
                             slot_dict.update(parsed)
                             changed = True
+                    if self._pgb_fetch is not None:
+                        self._pgb_fetch.complete()
 
             # Header 0x4F ('OK')
             elif data.startswith(b"OK"):
@@ -663,34 +664,17 @@ class PyHatchBabyRestAsync:
                 start = monotonic()
                 _LOGGER.debug("Started refresh_data at %s", datetime.now().isoformat())
 
-            self._set_active_operations(1)
-            await self._client_connect()
-
-            try:
-                if self._client and self._client.is_connected:
-                    # Request timer state explicitly
-                    await self._client.write_gatt_char(CHAR_TX, bytearray(b"GI"), response=True)
+            async with self._active_operation() as client:
+                if client and client.is_connected:
+                    await client.write_gatt_char(CHAR_TX, bytearray(b"GI"), response=True)
                     await asyncio.sleep(0.1)
-                    await self._client.write_gatt_char(CHAR_TX, bytearray(b"GD"), response=True)
+                    await client.write_gatt_char(CHAR_TX, bytearray(b"GD"), response=True)
                     await asyncio.sleep(0.1)
-
-                    raw_char_read = await self._client.read_gatt_char(CHAR_FEEDBACK)
+                    raw_char_read = await client.read_gatt_char(CHAR_FEEDBACK)
                     _LOGGER.debug("Raw char read from refresh_data: %s", raw_char_read)
                     self._parse_data(raw_char_read)
                 else:
                     _LOGGER.warning("Could not refresh data: Not connected to device")
-
-            except (
-                BleakNotFoundError,
-                BleakOutOfConnectionSlotsError,
-                BleakAbortedError,
-                BleakConnectionError,
-                Exception,  # noqa: BLE001
-            ) as e:
-                _LOGGER.warning("Exception during refresh_data -- %r", e)
-
-            self._set_active_operations(-1)
-            self._schedule_disconnect()
 
         if log_timing:
             _LOGGER.debug(
@@ -705,28 +689,38 @@ class PyHatchBabyRestAsync:
         _LOGGER.debug("API command: select_favorite %d", index)
         return await self._send_command(command, response=True)
 
-    async def save_to_favorite(self, index: int) -> None:
-        """Save current device state to a favorite slot.
-
-        Protocol confirmed via btsnoop: PSB opens the slot, PSC/PSN/PSV/PSLC0
-        set the fields, PSF commits. PSLC0 purpose is unknown but required.
-        """
-        r, g, b = self.color or (0, 0, 0)
-        brightness = self.brightness or 0
-        sound = (self.sound or PyHatchBabyRestSound.none).value
-        volume = self.volume or 0
-        _LOGGER.debug(
-            "API command: save_to_favorite slot=%d sound=%d vol=%d brightness=%d color=(%d,%d,%d)",
-            index, sound, volume, brightness, r, g, b,
-        )
-        await self._send_commands([
+    @staticmethod
+    def _build_ps_commands(
+        index: int,
+        flag: str,
+        color: tuple[int, int, int],
+        brightness: int,
+        sound: PyHatchBabyRestSound | int,
+        volume: int,
+    ) -> list[str]:
+        """Build the PSB→PSC→PSN→PSV→PSL→PSF command sequence for a favorite slot."""
+        r, g, b = color
+        sound_val = sound.value if isinstance(sound, PyHatchBabyRestSound) else int(sound)
+        return [
             f"PSB{index:02X}",
             f"PSC{r:02X}{g:02X}{b:02X}{brightness:02X}",
-            f"PSN{sound:02X}",
+            f"PSN{sound_val:02X}",
             f"PSV{volume:02X}",
-            "PSLC0",
+            f"PSL{flag}",
             "PSF",
-        ])
+        ]
+
+    async def save_to_favorite(self, index: int) -> None:
+        """Save current device state to a favorite slot."""
+        _LOGGER.debug("API command: save_to_favorite slot=%d", index)
+        commands = self._build_ps_commands(
+            index, "C0",
+            self.color or (0, 0, 0),
+            self.brightness or 0,
+            self.sound or PyHatchBabyRestSound.none,
+            self.volume or 0,
+        )
+        await self._send_commands(commands)
 
     async def get_timer(self) -> None:
         """Get the current timer state."""
@@ -750,29 +744,23 @@ class PyHatchBabyRestAsync:
         """Enable or disable a favorite slot.
 
         PSF commits ALL fields — must resend existing data alongside the new flag
-        or the slot gets wiped to defaults.
+        or the slot gets wiped to defaults. We connect first so the initial PGB
+        fetch has run and self.favorites is populated before we read it.
         """
         flag = "C0" if enable else "80"
         _LOGGER.debug("API command: toggle_favorite slot=%d enable=%s", index, enable)
-        cached = self.favorites.get(index, {})
-        color = cached.get("color") or (0, 0, 0)
-        r, g, b = color
-        brightness = cached.get("brightness") or 0
-        sound_raw = cached.get("sound") or PyHatchBabyRestSound.none
-        sound = sound_raw.value if hasattr(sound_raw, "value") else int(sound_raw)
-        volume = cached.get("volume") or 0
-        await self._send_commands(
-            [
-                f"PSB{index:02X}",
-                f"PSC{r:02X}{g:02X}{b:02X}{brightness:02X}",
-                f"PSN{sound:02X}",
-                f"PSV{volume:02X}",
-                f"PSL{flag}",
-                "PSF",
-                f"PGB{index:02X}",
-            ],
-            pgb_slot=index,
-        )
+        if index not in self.favorites:
+            _LOGGER.warning("toggle_favorite: no cached data for slot %d — skipping to avoid overwriting slot with zeros", index)
+            return
+        cached = self.favorites[index]
+        commands = self._build_ps_commands(
+            index, flag,
+            cached.get("color") or (0, 0, 0),
+            cached.get("brightness") or 0,
+            cached.get("sound") or PyHatchBabyRestSound.none,
+            cached.get("volume") or 0,
+        ) + [f"PGB{index:02X}"]
+        await self._send_commands(commands, pgb_slot=index)
 
     async def toggle_schedule(self, index: int, enable: bool) -> None:
         """Enable or disable a schedule slot."""

--- a/custom_components/hatch_rest/api.py
+++ b/custom_components/hatch_rest/api.py
@@ -6,6 +6,7 @@ https://github.com/kjoconnor/pyhatchbabyrest/blob/master/LICENSE
 
 """
 
+from collections import deque
 from collections.abc import Callable
 import asyncio
 from datetime import datetime
@@ -42,6 +43,7 @@ class PyHatchBabyRestAsync:
         # connection synchronization primitizes / state
         self._connection_cv = asyncio.Condition()
         self._connecting: bool = False
+        self._send_lock = asyncio.Lock()
         self._disconnect_timer: asyncio.TimerHandle | None = None
         self._callbacks: set[Callable[[], None]] = set()
         self._is_notifying: bool = False
@@ -53,14 +55,49 @@ class PyHatchBabyRestAsync:
         self.volume: int | None = None
         self.power: bool | None = None
         
+        # timer state
+        self.timer_total: int | None = None
+        self._timer_expires_at: float | None = None
+        
+        self.full_refresh_interval: int = 600 # seconds
+
+        self._init_collections()
+
+    @property
+    def timer_remaining(self) -> int | None:
+        """Return the remaining timer in minutes, calculated locally."""
+        if self._timer_expires_at is None:
+            return None
+        remaining = (self._timer_expires_at - monotonic()) / 60
+        if remaining <= 0:
+            return 0
+        return int(remaining + 0.01) # Small epsilon to handle precision issues
+
+    @timer_remaining.setter
+    def timer_remaining(self, value: int | None) -> None:
+        """Set the remaining timer in minutes and update expiration time."""
+        if value is not None:
+            # The device returns 65535 or 0xFFFF when no timer is active
+            if value >= 0xFFFF:
+                self._timer_expires_at = None
+                return
+            self._timer_expires_at = monotonic() + (value * 60)
+        else:
+            self._timer_expires_at = None
+
+    def _init_collections(self) -> None:
+        """Initialize collections."""
         self.favorites: dict[int, dict] = {}
         self.active_favorite: int | None = None
         self.schedules: dict[int, dict] = {}
         self._last_index_seen: int | None = None
         self._pending_slot: dict = {}  # buffered data before first index arrives
-        self._pgb_slot: int | None = None  # slot index of in-flight PGB (favorite) request
-        self._egb_slot: int | None = None  # slot index of in-flight EGB (schedule) request
+        self._pgb_slot: int | None = None  # slot index of in-flight PGB during initial fetch
+        self._egb_slot: int | None = None  # slot index of in-flight EGB during initial fetch
+        self._pending_pgb_slots: deque[int] = deque()  # slots queued from toggle_favorite
+        self._pending_egb_slots: deque[int] = deque()  # slots queued from toggle_schedule
         self._last_full_fetch: float | None = None  # monotonic time of last PGB+EGB sweep
+        self._pending_gf: bool = False  # True while waiting for a GF index response
 
     def update_ble_device(self, ble_device: BLEDevice) -> None:
         """Update the BLE device."""
@@ -145,6 +182,8 @@ class PyHatchBabyRestAsync:
             self._pending_slot = {}
             self._pgb_slot = None
             self._egb_slot = None
+            self._pending_pgb_slots.clear()
+            self._pending_egb_slots.clear()
 
             # Start notifications
             if client.is_connected:
@@ -161,6 +200,7 @@ class PyHatchBabyRestAsync:
                     # GF returns the active favorite index. Then PGB01-PGB06
                     # fetches each slot's config+name. Both confirmed via btsnoop.
                     _LOGGER.debug("Requesting active favorite index via 'GF'")
+                    self._pending_gf = True
                     await client.write_gatt_char(
                         CHAR_TX, bytearray(b"GF"), response=False
                     )
@@ -174,7 +214,7 @@ class PyHatchBabyRestAsync:
                     )
 
                     fetch_age = monotonic() - self._last_full_fetch if self._last_full_fetch else None
-                    if fetch_age is None or fetch_age > 3600:
+                    if fetch_age is None or fetch_age > self.full_refresh_interval:
                         _LOGGER.debug("Fetching favorites and schedules (age=%s)", fetch_age)
                         self.favorites = {}
                         self.schedules = {}
@@ -256,7 +296,9 @@ class PyHatchBabyRestAsync:
         commands: list[str],
         raw: bool = False,
         response: bool = True,
-        spacing_delay: float = 0.2,
+        spacing_delay: float = 0.1,
+        pgb_slot: int | None = None,
+        egb_slot: int | None = None,
     ):
         """Send a batch of commands to the device.
 
@@ -264,53 +306,63 @@ class PyHatchBabyRestAsync:
         :param raw: If True, decode command as hex string and send raw bytes.
         :param response: If True, wait for GATT-level acknowledgment.
         :param spacing_delay: Seconds to wait between commands in a batch.
+        :param pgb_slot: Favorite slot index expected in the PGB response (enqueued inside lock).
+        :param egb_slot: Schedule slot index expected in the EGB response (enqueued inside lock).
         """
-        if log_timing := _LOGGER.isEnabledFor(logging.DEBUG):
-            start = monotonic()
-            _LOGGER.debug(
-                "Started batch _send_commands at %s", datetime.now().isoformat()
-            )
+        async with self._send_lock:
+            if log_timing := _LOGGER.isEnabledFor(logging.DEBUG):
+                start = monotonic()
+                _LOGGER.debug(
+                    "Started batch _send_commands at %s", datetime.now().isoformat()
+                )
 
-        self._set_active_operations(1)
-        await self._client_connect()
+            self._set_active_operations(1)
+            await self._client_connect()
 
-        try:
-            if self._client and self._client.is_connected:
-                for i, command in enumerate(commands):
-                    data = (
-                        bytearray.fromhex(command)
-                        if raw
-                        else bytearray(command, "utf-8")
-                    )
-                    _LOGGER.debug("Sending command '%s' (Hex: %s)", command, data.hex())
-                    await self._client.write_gatt_char(
-                        char_specifier=CHAR_TX,
-                        data=data,
-                        response=response,
-                    )
-                    if i < len(commands) - 1 and spacing_delay > 0:
-                        await asyncio.sleep(spacing_delay)
-            else:
-                _LOGGER.warning("Could not send commands: Not connected to device")
+            # Register expected response slots AFTER connecting — _client_connect may clear
+            # the deques when reconnecting, so we enqueue only once the connection is stable.
+            if pgb_slot is not None:
+                self._pending_pgb_slots.append(pgb_slot)
+            if egb_slot is not None:
+                self._pending_egb_slots.append(egb_slot)
 
-        except (
-            BleakNotFoundError,
-            BleakOutOfConnectionSlotsError,
-            BleakAbortedError,
-            BleakConnectionError,
-            Exception,  # noqa: BLE001
-        ) as e:
-            _LOGGER.warning("Exception during _send_commands -- %r", e)
+            try:
+                if self._client and self._client.is_connected:
+                    for i, command in enumerate(commands):
+                        data = (
+                            bytearray.fromhex(command)
+                            if raw
+                            else bytearray(command, "utf-8")
+                        )
+                        _LOGGER.debug("Sending command '%s' (Hex: %s)", command, data.hex())
+                        await self._client.write_gatt_char(
+                            char_specifier=CHAR_TX,
+                            data=data,
+                            response=response,
+                        )
+                        if i < len(commands) - 1 and spacing_delay > 0:
+                            await asyncio.sleep(spacing_delay)
+                else:
+                    _LOGGER.warning("Could not send commands: Not connected to device")
 
-        self._set_active_operations(-1)
-        self._schedule_disconnect()
+            except (
+                BleakNotFoundError,
+                BleakOutOfConnectionSlotsError,
+                BleakAbortedError,
+                BleakConnectionError,
+                Exception,  # noqa: BLE001
+            ) as e:
+                _LOGGER.warning("Exception during _send_commands -- %r", e)
 
-        if log_timing:
-            _LOGGER.debug(
-                "Finished batch _send_commands at %s (total of %.3f seconds)",
-                datetime.now().isoformat(),
-                monotonic() - start,  # pyright: ignore[reportPossiblyUnboundVariable]
-            )
+            self._set_active_operations(-1)
+            self._schedule_disconnect()
+
+            if log_timing:
+                _LOGGER.debug(
+                    "Finished batch _send_commands at %s (total of %.3f seconds)",
+                    datetime.now().isoformat(),
+                    monotonic() - start,  # pyright: ignore[reportPossiblyUnboundVariable]
+                )
 
     async def _send_command(self, command: str, raw: bool = False, response: bool = True):
         """Send a single command to the device."""
@@ -350,6 +402,7 @@ class PyHatchBabyRestAsync:
         volume = data[2]
         brightness = data[9]
         blue, green, red = data[10], data[11], data[12]
+        flags = data[13] if len(data) > 13 else 0
         try:
             sound = PyHatchBabyRestSound(sound_id)
         except ValueError:
@@ -359,6 +412,7 @@ class PyHatchBabyRestAsync:
             "volume": volume,
             "brightness": brightness,
             "color": (red, green, blue),
+            "enabled": bool(flags & 0x80),  # bit 7: 0x96=enabled, 0x16=disabled (PSL C0 vs PSL 80)
             "raw": data.hex(),
         }
 
@@ -379,6 +433,7 @@ class PyHatchBabyRestAsync:
         brightness = data[13]
         blue, green, red = data[14], data[15], data[16]
         days_mask = data[18] if len(data) > 18 else 0
+        flags = data[19] if len(data) > 19 else 0
         modified_ts = struct.unpack_from("<I", data, 1)[0]
         days = {
             "mon": bool(days_mask & 0x02),
@@ -401,6 +456,7 @@ class PyHatchBabyRestAsync:
             "brightness": brightness,
             "color": (red, green, blue),
             "days": days,
+            "enabled": bool(flags & 0x40),
             "modified_ts": modified_ts,
             "raw": data.hex(),
         }
@@ -422,18 +478,42 @@ class PyHatchBabyRestAsync:
         changed = False
         try:
             header = data[0]
-            
-            # Header 0x30 is an Index block (ASCII "0", followed by index "1", "2"...)
-            if header == 0x30 and len(data) >= 2:
+
+            # GI response: "FF" = no timer active
+            if data == b"FF":
+                _LOGGER.debug("Timer: no timer active (GI=FF)")
+                if self.timer_total is not None or self.timer_remaining is not None:
+                    self.timer_total = None
+                    self.timer_remaining = None
+                    changed = True
+
+            # GD response: 4-char ASCII hex = remaining minutes (e.g. "0076" = 118 min)
+            elif len(data) == 4 and all(chr(b) in "0123456789ABCDEFabcdef" for b in data):
+                try:
+                    remaining = int(data.decode(), 16)
+                    _LOGGER.debug("Timer remaining: %d min (GD)", remaining)
+                    if self.timer_remaining != remaining:
+                        self.timer_remaining = remaining
+                        changed = True
+                except (ValueError, UnicodeDecodeError):
+                    pass
+
+            # Header 0x30 is GF active-favorite index — only trusted when we sent GF
+            elif self._pending_gf and header == 0x30 and len(data) >= 2:
+                self._pending_gf = False
                 index_str = data[1:2].decode("utf-8", errors="ignore")
                 if index_str.isdigit():
                     index = int(index_str)
                     if self.active_favorite != index:
-                        _LOGGER.debug("Active index (0x30): %d", index)
+                        _LOGGER.debug("Active favorite (GF): %d", index)
                         self.active_favorite = index
                         changed = True
                     self._last_index_seen = index
                     self._flush_pending_slot(index)
+
+            # Header 0x30 without _pending_gf = PSF/ESF slot-save confirmation — ignore
+            elif header == 0x30 and len(data) >= 2:
+                _LOGGER.debug("Slot-save confirmation (ignoring as active-favorite): %s", data.decode("utf-8", errors="ignore"))
 
             # Header 0x07 is an ASCII name block
             elif header == 0x07:
@@ -469,7 +549,10 @@ class PyHatchBabyRestAsync:
             elif header == 0x01 and len(data) >= 13:
                 if len(data) >= 20:
                     parsed = self._decode_schedule_block(data)
-                    idx = self._egb_slot or self._last_index_seen
+                    if self._pending_egb_slots:
+                        idx = self._pending_egb_slots.popleft()
+                    else:
+                        idx = self._egb_slot or self._last_index_seen
                     if idx is not None:
                         slot_dict = self.schedules.setdefault(idx, {})
                         if any(slot_dict.get(k) != v for k, v in parsed.items()):
@@ -478,14 +561,17 @@ class PyHatchBabyRestAsync:
                             changed = True
                 else:
                     parsed = self._decode_config_block(data)
-                    idx = self._pgb_slot or self._last_index_seen
+                    if self._pending_pgb_slots:
+                        idx = self._pending_pgb_slots.popleft()
+                    else:
+                        idx = self._pgb_slot or self._last_index_seen
                     if idx is None:
                         if any(self._pending_slot.get(k) != v for k, v in parsed.items()):
                             self._pending_slot.update(parsed)
                     else:
                         slot_dict = self.favorites.setdefault(idx, {})
                         if any(slot_dict.get(k) != v for k, v in parsed.items()):
-                            _LOGGER.debug("Favorite config slot %s: %s", self._pgb_slot, parsed)
+                            _LOGGER.debug("Favorite config slot %s: %s", idx, parsed)
                             slot_dict.update(parsed)
                             changed = True
 
@@ -572,32 +658,39 @@ class PyHatchBabyRestAsync:
 
     async def refresh_data(self):
         """Refresh data from Hatch Rest device."""
-        if log_timing := _LOGGER.isEnabledFor(logging.DEBUG):
-            start = monotonic()
-            _LOGGER.debug("Started refresh_data at %s", datetime.now().isoformat())
+        async with self._send_lock:
+            if log_timing := _LOGGER.isEnabledFor(logging.DEBUG):
+                start = monotonic()
+                _LOGGER.debug("Started refresh_data at %s", datetime.now().isoformat())
 
-        self._set_active_operations(1)
-        await self._client_connect()
+            self._set_active_operations(1)
+            await self._client_connect()
 
-        try:
-            if self._client and self._client.is_connected:
-                raw_char_read = await self._client.read_gatt_char(CHAR_FEEDBACK)
-                _LOGGER.debug("Raw char read from refresh_data: %s", raw_char_read)
-                self._parse_data(raw_char_read)
-            else:
-                _LOGGER.warning("Could not refresh data: Not connected to device")
+            try:
+                if self._client and self._client.is_connected:
+                    # Request timer state explicitly
+                    await self._client.write_gatt_char(CHAR_TX, bytearray(b"GI"), response=True)
+                    await asyncio.sleep(0.1)
+                    await self._client.write_gatt_char(CHAR_TX, bytearray(b"GD"), response=True)
+                    await asyncio.sleep(0.1)
 
-        except (
-            BleakNotFoundError,
-            BleakOutOfConnectionSlotsError,
-            BleakAbortedError,
-            BleakConnectionError,
-            Exception,  # noqa: BLE001
-        ) as e:
-            _LOGGER.warning("Exception during refresh_data -- %r", e)
+                    raw_char_read = await self._client.read_gatt_char(CHAR_FEEDBACK)
+                    _LOGGER.debug("Raw char read from refresh_data: %s", raw_char_read)
+                    self._parse_data(raw_char_read)
+                else:
+                    _LOGGER.warning("Could not refresh data: Not connected to device")
 
-        self._set_active_operations(-1)
-        self._schedule_disconnect()
+            except (
+                BleakNotFoundError,
+                BleakOutOfConnectionSlotsError,
+                BleakAbortedError,
+                BleakConnectionError,
+                Exception,  # noqa: BLE001
+            ) as e:
+                _LOGGER.warning("Exception during refresh_data -- %r", e)
+
+            self._set_active_operations(-1)
+            self._schedule_disconnect()
 
         if log_timing:
             _LOGGER.debug(
@@ -610,7 +703,7 @@ class PyHatchBabyRestAsync:
         """Select a favorite by index (confirmed via btsnoop: SP activates, PSB only edits)."""
         command = f"SP{index:02X}"
         _LOGGER.debug("API command: select_favorite %d", index)
-        return await self._send_command(command)
+        return await self._send_command(command, response=True)
 
     async def save_to_favorite(self, index: int) -> None:
         """Save current device state to a favorite slot.
@@ -640,11 +733,12 @@ class PyHatchBabyRestAsync:
         _LOGGER.debug("API command: get_timer (GI)")
         await self._send_command("GI")
 
-    async def set_timer(self, minutes: int) -> None:
-        """Set a timer for the specified number of minutes."""
-        # SD{hex} — confirmed timer set command
-        command = f"SD{minutes:04X}"
-        _LOGGER.debug("API command: set_timer %s (%d min)", command, minutes)
+    async def set_timer(self, seconds: int) -> None:
+        """Set a timer for the specified number of seconds."""
+        command = f"SD{seconds:04X}"
+        _LOGGER.debug("API command: set_timer %s (%d sec)", command, seconds)
+        self.timer_total = seconds // 60
+        self._timer_expires_at = monotonic() + seconds
         await self._send_command(command)
 
     async def get_timer_remaining(self) -> None:
@@ -653,56 +747,69 @@ class PyHatchBabyRestAsync:
         await self._send_command("GD")
 
     async def toggle_favorite(self, index: int, enable: bool) -> None:
-        """Enable or disable a favorite slot."""
-        # PSL is enable/disable flag: 0xC0 = enabled, 0x80 = disabled
-        # Sequence: PSB{index} -> PSL{flag} -> PSF
+        """Enable or disable a favorite slot.
+
+        PSF commits ALL fields — must resend existing data alongside the new flag
+        or the slot gets wiped to defaults.
+        """
         flag = "C0" if enable else "80"
         _LOGGER.debug("API command: toggle_favorite slot=%d enable=%s", index, enable)
-        await self._send_commands([
-            f"PSB{index:02X}",
-            f"PSL{flag}",
-            "PSF",
-        ])
+        cached = self.favorites.get(index, {})
+        color = cached.get("color") or (0, 0, 0)
+        r, g, b = color
+        brightness = cached.get("brightness") or 0
+        sound_raw = cached.get("sound") or PyHatchBabyRestSound.none
+        sound = sound_raw.value if hasattr(sound_raw, "value") else int(sound_raw)
+        volume = cached.get("volume") or 0
+        await self._send_commands(
+            [
+                f"PSB{index:02X}",
+                f"PSC{r:02X}{g:02X}{b:02X}{brightness:02X}",
+                f"PSN{sound:02X}",
+                f"PSV{volume:02X}",
+                f"PSL{flag}",
+                "PSF",
+                f"PGB{index:02X}",
+            ],
+            pgb_slot=index,
+        )
 
     async def toggle_schedule(self, index: int, enable: bool) -> None:
         """Enable or disable a schedule slot."""
-        # ESL is likely the schedule version of PSL
-        # Sequence: ESB{index} -> ESL{flag} -> ESF
         flag = "C0" if enable else "80"
         _LOGGER.debug("API command: toggle_schedule slot=%d enable=%s", index, enable)
-        await self._send_commands([
-            f"ESB{index:02X}",
-            f"ESL{flag}",
-            "ESF",
-        ])
+        await self._send_commands(
+            [f"ESB{index:02X}", f"ESL{flag}", "ESF", f"EGB{index:02X}"],
+            egb_slot=index,
+        )
 
     async def turn_power_on(self):
         """Power on the Hatch Rest device."""
         command = f"SI{1:02x}"
         _LOGGER.debug("API command: turn_power_on")
         self.power = True
-        await self._send_command(command, response=False)
+        await self._send_command(command, response=True)
 
     async def turn_power_off(self):
         """Power off the Hatch Rest device."""
         command = f"SI{0:02x}"
         _LOGGER.debug("API command: turn_power_off")
         self.power = False
-        await self._send_command(command, response=False)
+        await self._send_command(command, response=True)
 
     async def set_sound(self, sound: int):
         """Set the sound of the Hatch Rest device."""
         command = f"SN{sound:02x}"
         _LOGGER.debug("API command: set_sound to %s", command)
         self.sound = PyHatchBabyRestSound(sound)
-        return await self._send_command(command, response=False)
+        return await self._send_command(command, response=True)
 
     async def set_volume(self, volume: int):
         """Set the volume of the Hatch Rest device."""
         command = f"SV{volume:02x}"
         _LOGGER.debug("API command: set_volume to %s", command)
         self.volume = volume
-        return await self._send_command(command, response=False)
+        return await self._send_command(command, response=True)
 
     async def set_color(self, red: int, green: int, blue: int):
         """Set the color of the Hatch Rest device."""
@@ -726,7 +833,7 @@ class PyHatchBabyRestAsync:
         if self.color is not None and self.brightness is not None:
             command = f"SC{self.color[0]:02x}{self.color[1]:02x}{self.color[2]:02x}{self.brightness:02x}"
             _LOGGER.debug("API command: set_light_state to %s", command)
-            return await self._send_command(command, response=False)
+            return await self._send_command(command, response=True)
         return None
 
     @property

--- a/custom_components/hatch_rest/config_flow.py
+++ b/custom_components/hatch_rest/config_flow.py
@@ -6,7 +6,7 @@ from typing import Any
 
 import voluptuous as vol
 
-from homeassistant import config_entries
+from homeassistant import config_entries, core
 from homeassistant.components.bluetooth import (
     BluetoothServiceInfoBleak,
     async_ble_device_from_address,
@@ -16,7 +16,7 @@ from homeassistant.config_entries import ConfigFlowResult
 from homeassistant.const import CONF_ADDRESS, CONF_SENSOR_TYPE
 
 from .api import PyHatchBabyRestAsync
-from .const import DOMAIN, MANUFACTURER_ID
+from .const import CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL, DOMAIN, MANUFACTURER_ID
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -97,10 +97,25 @@ class HatchBabyRestConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self._set_confirm_only()
         return self.async_show_form(
             step_id="bluetooth_confirm",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(
+                        CONF_SCAN_INTERVAL, default=DEFAULT_SCAN_INTERVAL
+                    ): vol.All(vol.Coerce(int), vol.Range(min=1, max=1440)),
+                }
+            ),
             description_placeholders={
                 "name": self.context["title_placeholders"]["name"]
             },
         )
+
+    @core.callback
+    @staticmethod
+    def async_get_options_flow(
+        config_entry: config_entries.ConfigEntry,
+    ) -> config_entries.OptionsFlow:
+        """Get the options flow for this handler."""
+        return HatchBabyRestOptionsFlowHandler(config_entry)
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
@@ -153,7 +168,14 @@ class HatchBabyRestConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         }
         return self.async_show_form(
             step_id="user",
-            data_schema=vol.Schema({vol.Required(CONF_ADDRESS): vol.In(titles)}),
+            data_schema=vol.Schema(
+                {
+                    vol.Required(CONF_ADDRESS): vol.In(titles),
+                    vol.Required(
+                        CONF_SCAN_INTERVAL, default=DEFAULT_SCAN_INTERVAL
+                    ): vol.All(vol.Coerce(int), vol.Range(min=1, max=1440)),
+                }
+            ),
         )
 
     async def _async_create_entry_from_discovery(
@@ -168,4 +190,36 @@ class HatchBabyRestConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 CONF_ADDRESS: address,
                 CONF_SENSOR_TYPE: "switch",  # is this even required? I have other platforms supported
             },
+        )
+
+
+class HatchBabyRestOptionsFlowHandler(config_entries.OptionsFlow):
+    """Hatch Rest options flow handler."""
+
+    def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
+        """Initialize Hatch Rest options flow."""
+        self.config_entry = config_entry
+
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Manage the options."""
+        if user_input is not None:
+            return self.async_create_entry(title="", data=user_input)
+
+        return self.async_show_form(
+            step_id="init",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(
+                        CONF_SCAN_INTERVAL,
+                        default=self.config_entry.options.get(
+                            CONF_SCAN_INTERVAL,
+                            self.config_entry.data.get(
+                                CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL
+                            ),
+                        ),
+                    ): vol.All(vol.Coerce(int), vol.Range(min=1, max=1440)),
+                }
+            ),
         )

--- a/custom_components/hatch_rest/config_flow.py
+++ b/custom_components/hatch_rest/config_flow.py
@@ -115,7 +115,7 @@ class HatchBabyRestConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         config_entry: config_entries.ConfigEntry,
     ) -> config_entries.OptionsFlow:
         """Get the options flow for this handler."""
-        return HatchBabyRestOptionsFlowHandler(config_entry)
+        return HatchBabyRestOptionsFlowHandler()
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
@@ -195,10 +195,6 @@ class HatchBabyRestConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
 class HatchBabyRestOptionsFlowHandler(config_entries.OptionsFlow):
     """Hatch Rest options flow handler."""
-
-    def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
-        """Initialize Hatch Rest options flow."""
-        self.config_entry = config_entry
 
     async def async_step_init(
         self, user_input: dict[str, Any] | None = None

--- a/custom_components/hatch_rest/const.py
+++ b/custom_components/hatch_rest/const.py
@@ -7,8 +7,8 @@ MANUFACTURER_ID = 1076
 
 COLOR_GRADIENT = (254, 254, 254)  # setting this color turns on Gradient mode
 CHAR_TX = "02240002-5efd-47eb-9c1a-de53f7a2b232"
+CHAR_LIST = "02240003-5efd-47eb-9c1a-de53f7a2b232"
 CHAR_FEEDBACK = "02260002-5efd-47eb-9c1a-de53f7a2b232"
-BT_MANUFACTURER_ID = 1076
 
 
 class PyHatchBabyRestSound(IntEnum):

--- a/custom_components/hatch_rest/const.py
+++ b/custom_components/hatch_rest/const.py
@@ -5,6 +5,9 @@ from enum import IntEnum
 DOMAIN = "hatch_rest"
 MANUFACTURER_ID = 1076
 
+CONF_SCAN_INTERVAL = "scan_interval"
+DEFAULT_SCAN_INTERVAL = 10  # minutes
+
 COLOR_GRADIENT = (254, 254, 254)  # setting this color turns on Gradient mode
 CHAR_TX = "02240002-5efd-47eb-9c1a-de53f7a2b232"
 CHAR_LIST = "02240003-5efd-47eb-9c1a-de53f7a2b232"

--- a/custom_components/hatch_rest/coordinator.py
+++ b/custom_components/hatch_rest/coordinator.py
@@ -10,7 +10,6 @@ from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.update_coordinator import (
     CoordinatorEntity,
     DataUpdateCoordinator,
-    UpdateFailed,
 )
 
 from .api import PyHatchBabyRestAsync
@@ -33,7 +32,7 @@ class HatchBabyRestUpdateCoordinator(DataUpdateCoordinator):
             hass,
             _LOGGER,
             name=DOMAIN,
-            update_interval=timedelta(seconds=60),
+            update_interval=timedelta(hours=1),
         )
         self.unique_id = unique_id
         self.hatch_rest_device = hatch_rest_device
@@ -52,6 +51,7 @@ class HatchBabyRestUpdateCoordinator(DataUpdateCoordinator):
             {"address": self._address, "connectable": True},
             bluetooth.BluetoothScanningMode.PASSIVE,
         )
+
 
     @callback
     def _handle_advertisement(
@@ -93,16 +93,12 @@ class HatchBabyRestUpdateCoordinator(DataUpdateCoordinator):
         try:
             await self.hatch_rest_device.refresh_data()
         except Exception as e:
-            _LOGGER.warning(
-                "_async_update_data failed to refresh Hatch Rest data: %r", e
-            )
-            # Don’t raise; use previous successful data if available
+            _LOGGER.warning("_async_update_data failed: %r", e)
             if self._last_data:
-                _LOGGER.debug("Using cached data due to _async_update_data failure")
                 return self._last_data
+            from homeassistant.helpers.update_coordinator import UpdateFailed
             raise UpdateFailed(f"Device update failed: {e}") from e
-        else:
-            return self.get_current_data()
+        return self.get_current_data()
 
 
 class HatchBabyRestEntity(CoordinatorEntity[HatchBabyRestUpdateCoordinator]):

--- a/custom_components/hatch_rest/coordinator.py
+++ b/custom_components/hatch_rest/coordinator.py
@@ -1,12 +1,12 @@
 """Hatch Rest coordinator."""
 
-import asyncio
 from datetime import datetime, timedelta
 import logging
 
 from homeassistant.components import bluetooth
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers.event import async_call_later
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.update_coordinator import (
     CoordinatorEntity,
@@ -42,7 +42,7 @@ class HatchBabyRestUpdateCoordinator(DataUpdateCoordinator):
             str, int | tuple[int, int, int] | bool | PyHatchBabyRestSound | None | datetime
         ] = {}
 
-        self._refresh_timer: asyncio.TimerHandle | None = None
+        self._refresh_timer = None
         self._advertisement_hint: bool = False
 
         # Register callback for real-time updates from connections
@@ -83,12 +83,15 @@ class HatchBabyRestUpdateCoordinator(DataUpdateCoordinator):
     def _schedule_deep_refresh(self) -> None:
         """Schedule a deep refresh after a debounce period."""
         if self._refresh_timer:
-            self._refresh_timer.cancel()
+            self._refresh_timer()
+            self._refresh_timer = None
+
+        @callback
+        def _fire(_now):
+            self.hass.async_create_task(self._debounced_refresh())
 
         # 10s debounce to let manual/app changes settle before HA connects
-        self._refresh_timer = self.hass.loop.call_later(
-            10, lambda: self.hass.async_create_task(self._debounced_refresh())
-        )
+        self._refresh_timer = async_call_later(self.hass, 10, _fire)
         _LOGGER.debug("Scheduled debounced deep refresh in 10s")
 
     async def _debounced_refresh(self) -> None:

--- a/custom_components/hatch_rest/coordinator.py
+++ b/custom_components/hatch_rest/coordinator.py
@@ -45,18 +45,12 @@ class HatchBabyRestUpdateCoordinator(DataUpdateCoordinator):
         self.hatch_rest_device.register_callback(self._handle_api_update)
 
         # Register callback for passive advertisements
-        self._async_setup_advertisement_callback()
-
-    @callback
-    def _async_setup_advertisement_callback(self) -> None:
-        """Set up the advertisement callback."""
-        self.async_add_listener(
-            bluetooth.async_register_callback(
-                self.hass,
-                self._handle_advertisement,
-                {"address": self.hatch_rest_device.address, "connectable": True},
-                bluetooth.BluetoothScanningMode.PASSIVE,
-            )
+        self._address = self.hatch_rest_device.address.upper()
+        self._cancel_bluetooth_advertisements = bluetooth.async_register_callback(
+            self.hass,
+            self._handle_advertisement,
+            {"address": self._address, "connectable": True},
+            bluetooth.BluetoothScanningMode.PASSIVE,
         )
 
     @callback

--- a/custom_components/hatch_rest/coordinator.py
+++ b/custom_components/hatch_rest/coordinator.py
@@ -1,5 +1,6 @@
 """Hatch Rest coordinator."""
 
+import asyncio
 from datetime import datetime, timedelta
 import logging
 
@@ -38,8 +39,11 @@ class HatchBabyRestUpdateCoordinator(DataUpdateCoordinator):
         self.unique_id = unique_id
         self.hatch_rest_device = hatch_rest_device
         self._last_data: dict[
-            str, int | tuple[int, int, int] | bool | PyHatchBabyRestSound | None
+            str, int | tuple[int, int, int] | bool | PyHatchBabyRestSound | None | datetime
         ] = {}
+
+        self._refresh_timer: asyncio.TimerHandle | None = None
+        self._advertisement_hint: bool = False
 
         # Register callback for real-time updates from connections
         self.hatch_rest_device.register_callback(self._handle_api_update)
@@ -53,7 +57,6 @@ class HatchBabyRestUpdateCoordinator(DataUpdateCoordinator):
             bluetooth.BluetoothScanningMode.PASSIVE,
         )
 
-
     @callback
     def _handle_advertisement(
         self,
@@ -62,13 +65,42 @@ class HatchBabyRestUpdateCoordinator(DataUpdateCoordinator):
     ) -> None:
         """Handle an advertisement from the device."""
         _LOGGER.debug("Received advertisement for %s", service_info.address)
+        # Set a hint flag so we know this change came from an advertisement
+        self._advertisement_hint = True
         self.hatch_rest_device.update_from_advertisement(service_info)
-        # Note: update_from_advertisement will trigger the API callback if state changed
+        self._advertisement_hint = False
 
     def _handle_api_update(self) -> None:
         """Handle pushed updates from the API."""
         _LOGGER.debug("API pushed an update, updating coordinator data")
         self.async_set_updated_data(self.get_current_data())
+
+        # If the update was triggered by a passive advertisement, schedule a deep refresh
+        # to catch timer or favorite changes that aren't in the advertisement.
+        if self._advertisement_hint:
+            self._schedule_deep_refresh()
+
+    def _schedule_deep_refresh(self) -> None:
+        """Schedule a deep refresh after a debounce period."""
+        if self._refresh_timer:
+            self._refresh_timer.cancel()
+
+        # 10s debounce to let manual/app changes settle before HA connects
+        self._refresh_timer = self.hass.loop.call_later(
+            10, lambda: self.hass.async_create_task(self._debounced_refresh())
+        )
+        _LOGGER.debug("Scheduled debounced deep refresh in 10s")
+
+    async def _debounced_refresh(self) -> None:
+        """Perform the debounced refresh."""
+        self._refresh_timer = None
+        # Don't trigger if we are already communicating with the device
+        if self.hatch_rest_device._active_operations > 0:
+            _LOGGER.debug("Skipping debounced refresh, device already busy")
+            return
+
+        _LOGGER.debug("Executing debounced deep refresh")
+        await self.async_refresh()
 
     def get_current_data(
         self,

--- a/custom_components/hatch_rest/coordinator.py
+++ b/custom_components/hatch_rest/coordinator.py
@@ -3,7 +3,8 @@
 from datetime import timedelta
 import logging
 
-from homeassistant.core import HomeAssistant
+from homeassistant.components import bluetooth
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.update_coordinator import (
@@ -39,6 +40,40 @@ class HatchBabyRestUpdateCoordinator(DataUpdateCoordinator):
         self._last_data: dict[
             str, int | tuple[int, int, int] | bool | PyHatchBabyRestSound | None
         ] = {}
+
+        # Register callback for real-time updates from connections
+        self.hatch_rest_device.register_callback(self._handle_api_update)
+
+        # Register callback for passive advertisements
+        self._async_setup_advertisement_callback()
+
+    @callback
+    def _async_setup_advertisement_callback(self) -> None:
+        """Set up the advertisement callback."""
+        self.async_add_listener(
+            bluetooth.async_register_callback(
+                self.hass,
+                self._handle_advertisement,
+                {"address": self.hatch_rest_device.address, "connectable": True},
+                bluetooth.BluetoothScanningMode.PASSIVE,
+            )
+        )
+
+    @callback
+    def _handle_advertisement(
+        self,
+        service_info: bluetooth.BluetoothServiceInfoBleak,
+        change: bluetooth.BluetoothChange,
+    ) -> None:
+        """Handle an advertisement from the device."""
+        _LOGGER.debug("Received advertisement for %s", service_info.address)
+        self.hatch_rest_device.update_from_advertisement(service_info)
+        # Note: update_from_advertisement will trigger the API callback if state changed
+
+    def _handle_api_update(self) -> None:
+        """Handle pushed updates from the API."""
+        _LOGGER.debug("API pushed an update, updating coordinator data")
+        self.async_set_updated_data(self.get_current_data())
 
     def get_current_data(
         self,

--- a/custom_components/hatch_rest/coordinator.py
+++ b/custom_components/hatch_rest/coordinator.py
@@ -1,6 +1,6 @@
 """Hatch Rest coordinator."""
 
-from datetime import timedelta
+from datetime import datetime, timedelta
 import logging
 
 from homeassistant.components import bluetooth
@@ -26,13 +26,14 @@ class HatchBabyRestUpdateCoordinator(DataUpdateCoordinator):
         hass: HomeAssistant,
         unique_id: str | None,
         hatch_rest_device: PyHatchBabyRestAsync,
+        update_interval: timedelta,
     ) -> None:
         """Initialize the coordinator."""
         super().__init__(
             hass,
             _LOGGER,
             name=DOMAIN,
-            update_interval=timedelta(hours=1),
+            update_interval=update_interval,
         )
         self.unique_id = unique_id
         self.hatch_rest_device = hatch_rest_device
@@ -71,16 +72,29 @@ class HatchBabyRestUpdateCoordinator(DataUpdateCoordinator):
 
     def get_current_data(
         self,
-    ) -> dict[str, int | tuple[int, int, int] | bool | PyHatchBabyRestSound | None]:
+    ) -> dict[str, int | tuple[int, int, int] | bool | PyHatchBabyRestSound | None | datetime]:
         """Get the current state of the Hatch Rest device."""
+        timer_expires_at = self.hatch_rest_device._timer_expires_at
+        timer_end_time = None
+        if timer_expires_at is not None:
+            # Convert monotonic time to UTC datetime
+            from homeassistant.util import dt as dt_util
+            from time import monotonic
+            
+            remaining = timer_expires_at - monotonic()
+            timer_end_time = dt_util.utcnow() + timedelta(seconds=remaining)
+
         data: dict[
-            str, int | tuple[int, int, int] | bool | PyHatchBabyRestSound | None
+            str, int | tuple[int, int, int] | bool | PyHatchBabyRestSound | None | datetime
         ] = {
             "brightness": self.hatch_rest_device.brightness,
             "color": self.hatch_rest_device.color,
             "power": self.hatch_rest_device.power,
             "sound": self.hatch_rest_device.sound,
             "volume": self.hatch_rest_device.volume,
+            "timer_total": self.hatch_rest_device.timer_total,
+            "timer_remaining": self.hatch_rest_device.timer_remaining,
+            "timer_end_time": timer_end_time,
         }
         _LOGGER.debug("Data updated: %s", data)
         return data

--- a/custom_components/hatch_rest/light.py
+++ b/custom_components/hatch_rest/light.py
@@ -83,23 +83,17 @@ class HatchBabyRestLight(HatchBabyRestEntity, LightEntity):  # pyright: ignore[r
             _LOGGER.debug("light _hatch_rest_device power not on -- turning on")
             await self._hatch_rest_device.turn_power_on()
 
-        if brightness:
-            _LOGGER.debug("light setting brightness = %s", brightness)
-            await self._hatch_rest_device.set_brightness(brightness)
-        if rgb:
-            _LOGGER.debug("light setting RBG = (%s[0], %s[1], %s[2])", *rgb)
-            await self._hatch_rest_device.set_color(*rgb)
+        if brightness is not None or rgb is not None:
+            _LOGGER.debug("light setting state: brightness=%s, rgb=%s", brightness, rgb)
+            await self._hatch_rest_device.set_light_state(brightness=brightness, color=rgb)
 
-        # https://developers.home-assistant.io/docs/integration_fetching_data/
-        # If this method is used on a coordinator that polls, it will reset the time until the next time it will poll for data.
-        # each _send_command calls _refresh_data and updates API data states, so use that
+        # The API now performs optimistic updates to self._hatch_rest_device
+        # We trigger a coordinator refresh to ensure Home Assistant sees the new state immediately
         self.coordinator.async_set_updated_data(self.coordinator.get_current_data())
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Set the light off."""
         await self._hatch_rest_device.set_brightness(0)
 
-        # https://developers.home-assistant.io/docs/integration_fetching_data/
-        # If this method is used on a coordinator that polls, it will reset the time until the next time it will poll for data.
-        # each _send_command calls _refresh_data and updates API data states, so use that
+        # The API now performs optimistic updates to self._hatch_rest_device
         self.coordinator.async_set_updated_data(self.coordinator.get_current_data())

--- a/custom_components/hatch_rest/light.py
+++ b/custom_components/hatch_rest/light.py
@@ -5,8 +5,10 @@ from typing import Any
 
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
+    ATTR_EFFECT,
     ATTR_RGB_COLOR,
     LightEntity,
+    LightEntityFeature,
 )
 from homeassistant.components.light.const import ColorMode
 from homeassistant.config_entries import ConfigEntry
@@ -14,8 +16,11 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .coordinator import HatchBabyRestEntity
+from .const import COLOR_GRADIENT
 
 _LOGGER = logging.getLogger(__name__)
+
+EFFECT_RAINBOW = "Rainbow"
 
 
 async def async_setup_entry(
@@ -31,6 +36,9 @@ async def async_setup_entry(
 
 class HatchBabyRestLight(HatchBabyRestEntity, LightEntity):  # pyright: ignore[reportIncompatibleVariableOverride]
     """Hatch Rest light entity."""
+
+    _attr_effect_list = [EFFECT_RAINBOW]
+    _attr_supported_features = LightEntityFeature.EFFECT
 
     @property
     def brightness(self) -> int | None:  # pyright: ignore[reportIncompatibleVariableOverride]
@@ -74,10 +82,22 @@ class HatchBabyRestLight(HatchBabyRestEntity, LightEntity):  # pyright: ignore[r
         """Return supported color modes."""
         return {ColorMode.RGB}
 
+    @property
+    def effect(self) -> str | None:
+        """Return the current effect."""
+        if self.coordinator.data.get("color") == COLOR_GRADIENT:
+            return EFFECT_RAINBOW
+        return None
+
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Set the light on."""
         brightness = kwargs.get(ATTR_BRIGHTNESS)
         rgb = kwargs.get(ATTR_RGB_COLOR)
+        effect = kwargs.get(ATTR_EFFECT)
+
+        # If the rainbow effect is requested, override the color
+        if effect == EFFECT_RAINBOW:
+            rgb = COLOR_GRADIENT
 
         # If the whole device is powered off, we must turn it on to see the light
         if not self._hatch_rest_device.power:

--- a/custom_components/hatch_rest/light.py
+++ b/custom_components/hatch_rest/light.py
@@ -79,21 +79,26 @@ class HatchBabyRestLight(HatchBabyRestEntity, LightEntity):  # pyright: ignore[r
         brightness = kwargs.get(ATTR_BRIGHTNESS)
         rgb = kwargs.get(ATTR_RGB_COLOR)
 
+        # If the whole device is powered off, we must turn it on to see the light
         if not self._hatch_rest_device.power:
-            _LOGGER.debug("light _hatch_rest_device power not on -- turning on")
+            _LOGGER.debug("light turning device power on")
             await self._hatch_rest_device.turn_power_on()
 
+        # If we have specific attributes (color/brightness), apply them
         if brightness is not None or rgb is not None:
             _LOGGER.debug("light setting state: brightness=%s, rgb=%s", brightness, rgb)
             await self._hatch_rest_device.set_light_state(brightness=brightness, color=rgb)
+        
+        # If we are just toggling "On" and the current brightness is 0, we need to bring it up
+        elif self._hatch_rest_device.brightness == 0:
+            _LOGGER.debug("light was at 0 brightness, restoring to full")
+            await self._hatch_rest_device.set_brightness(255)
 
-        # The API now performs optimistic updates to self._hatch_rest_device
-        # We trigger a coordinator refresh to ensure Home Assistant sees the new state immediately
         self.coordinator.async_set_updated_data(self.coordinator.get_current_data())
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Set the light off."""
+        _LOGGER.debug("light dimming to 0 (off)")
         await self._hatch_rest_device.set_brightness(0)
 
-        # The API now performs optimistic updates to self._hatch_rest_device
         self.coordinator.async_set_updated_data(self.coordinator.get_current_data())

--- a/custom_components/hatch_rest/media_player.py
+++ b/custom_components/hatch_rest/media_player.py
@@ -76,28 +76,19 @@ class HatchBabyRestMediaPlayer(HatchBabyRestEntity, MediaPlayerEntity):  # pyrig
     @property
     def source(self) -> str | None:  # pyright: ignore[reportIncompatibleVariableOverride]
         """Return the current source of the media player."""
-        active_fav = self.coordinator.hatch_rest_device.active_favorite
-        if active_fav:
-            fav_info = self.coordinator.hatch_rest_device.favorites.get(active_fav, {})
-            return fav_info.get("name", f"Favorite {active_fav}")
-            
         sound = self.coordinator.data.get("sound")
-        if sound:
+        if sound is None or sound == PyHatchBabyRestSound.none:
+            return None
+        if hasattr(sound, "name"):
             return sound.name.capitalize()
-        return None
+        return f"Unknown ({sound})"
 
     @property
     def source_list(self) -> list[str] | None:  # pyright: ignore[reportIncompatibleVariableOverride]
         """Return a list of available sources."""
-        sources = []
-        # Add Favorites first
-        for i in range(1, 7):
-            fav_info = self.coordinator.hatch_rest_device.favorites.get(i, {})
-            sources.append(fav_info.get("name", f"Favorite {i}"))
-        
-        # Add raw sounds
-        sources.extend([sound.name.capitalize() for sound in PyHatchBabyRestSound if sound.name != "none"])
-        return sources
+        favorites = [f"Favorite {i}" for i in range(1, 7)]
+        sounds = [sound.name.capitalize() for sound in PyHatchBabyRestSound if sound.name != "none"]
+        return favorites + sounds
 
     @property
     def state(self) -> MediaPlayerState | None:  # pyright: ignore[reportIncompatibleVariableOverride]
@@ -145,31 +136,28 @@ class HatchBabyRestMediaPlayer(HatchBabyRestEntity, MediaPlayerEntity):  # pyrig
     async def async_select_source(self, source: str) -> None:
         """Select a source from the list of available sources."""
         _LOGGER.debug("media_player selecting source: %s", source)
-        
-        # Check if it's a favorite (either by index name or custom name)
-        selected_index = None
-        for i in range(1, 7):
-            fav_info = self._hatch_rest_device.favorites.get(i, {})
-            if source == fav_info.get("name") or source == f"Favorite {i}":
-                selected_index = i
-                break
-        
-        if selected_index is not None:
-            _LOGGER.debug("media_player selecting favorite %d", selected_index)
-            await self._hatch_rest_device.select_favorite(selected_index)
-        else:
-            # Fallback to raw sound IDs
+
+        if source.startswith("Favorite "):
             try:
-                source_number = PyHatchBabyRestSound[source.lower()]
-                self._previous_sound = PyHatchBabyRestSound(source_number)
-                _LOGGER.debug(
-                    "media_player setting sound = %d (%s) ",
-                    source_number,
-                    PyHatchBabyRestSound(source_number).name,
-                )
-                await self._hatch_rest_device.set_sound(source_number)
-            except KeyError:
-                _LOGGER.error("Invalid source selected: %s", source)
+                index = int(source.split(" ")[1])
+                await self._hatch_rest_device.select_favorite(index)
+                await self.coordinator.async_refresh()
+                return
+            except (ValueError, IndexError):
+                _LOGGER.error("Invalid favorite source: %s", source)
+                return
+
+        try:
+            source_number = PyHatchBabyRestSound[source.lower()]
+            self._previous_sound = PyHatchBabyRestSound(source_number)
+            _LOGGER.debug(
+                "media_player setting sound = %d (%s) ",
+                source_number,
+                PyHatchBabyRestSound(source_number).name,
+            )
+            await self._hatch_rest_device.set_sound(source_number)
+        except KeyError:
+            _LOGGER.error("Invalid source selected: %s", source)
 
         # https://developers.home-assistant.io/docs/integration_fetching_data/
         # If this method is used on a coordinator that polls, it will reset the time until the next time it will poll for data.

--- a/custom_components/hatch_rest/media_player.py
+++ b/custom_components/hatch_rest/media_player.py
@@ -39,6 +39,29 @@ class HatchBabyRestMediaPlayer(HatchBabyRestEntity, MediaPlayerEntity):  # pyrig
         self._previous_sound: PyHatchBabyRestSound | None = None
 
     @property
+    def extra_state_attributes(self) -> dict | None:
+        """Expose schedules and active favorite as state attributes."""
+        device = self._hatch_rest_device
+        schedules = []
+        for slot, data in sorted(device.schedules.items()):
+            sound = data.get("sound")
+            schedules.append({
+                "slot": slot,
+                "name": data.get("name", f"Schedule {slot}"),
+                "hour": data.get("hour"),
+                "minute": data.get("minute"),
+                "days": data.get("days"),
+                "sound": sound.name if hasattr(sound, "name") else sound,
+                "volume": data.get("volume"),
+                "brightness": data.get("brightness"),
+                "color": data.get("color"),
+            })
+        return {
+            "schedules": schedules,
+            "active_favorite": device.active_favorite,
+        }
+
+    @property
     def device_class(self) -> MediaPlayerDeviceClass | None:  # pyright: ignore[reportIncompatibleVariableOverride]
         """Return the device class of the media player."""
         return MediaPlayerDeviceClass.SPEAKER
@@ -53,14 +76,11 @@ class HatchBabyRestMediaPlayer(HatchBabyRestEntity, MediaPlayerEntity):  # pyrig
     @property
     def source(self) -> str | None:  # pyright: ignore[reportIncompatibleVariableOverride]
         """Return the current source of the media player."""
-        if self.coordinator.data.get("sound"):
-            _LOGGER.debug(
-                "media_player source = %d (%s)",
-                self.coordinator.data.get("sound"),
-                PyHatchBabyRestSound(self.coordinator.data.get("sound")).name,
-            )
-        else:
-            _LOGGER.debug("media_player source = None")
+        active_fav = self.coordinator.hatch_rest_device.active_favorite
+        if active_fav:
+            fav_info = self.coordinator.hatch_rest_device.favorites.get(active_fav, {})
+            return fav_info.get("name", f"Favorite {active_fav}")
+            
         sound = self.coordinator.data.get("sound")
         if sound:
             return sound.name.capitalize()
@@ -69,7 +89,15 @@ class HatchBabyRestMediaPlayer(HatchBabyRestEntity, MediaPlayerEntity):  # pyrig
     @property
     def source_list(self) -> list[str] | None:  # pyright: ignore[reportIncompatibleVariableOverride]
         """Return a list of available sources."""
-        return [sound.name.capitalize() for sound in PyHatchBabyRestSound]
+        sources = []
+        # Add Favorites first
+        for i in range(1, 7):
+            fav_info = self.coordinator.hatch_rest_device.favorites.get(i, {})
+            sources.append(fav_info.get("name", f"Favorite {i}"))
+        
+        # Add raw sounds
+        sources.extend([sound.name.capitalize() for sound in PyHatchBabyRestSound if sound.name != "none"])
+        return sources
 
     @property
     def state(self) -> MediaPlayerState | None:  # pyright: ignore[reportIncompatibleVariableOverride]
@@ -116,14 +144,32 @@ class HatchBabyRestMediaPlayer(HatchBabyRestEntity, MediaPlayerEntity):  # pyrig
 
     async def async_select_source(self, source: str) -> None:
         """Select a source from the list of available sources."""
-        source_number = PyHatchBabyRestSound[source.lower()]
-        self._previous_sound = PyHatchBabyRestSound(source_number)
-        _LOGGER.debug(
-            "media_player setting source = %d (%s) ",
-            source_number,
-            PyHatchBabyRestSound(source_number).name,
-        )
-        await self._hatch_rest_device.set_sound(source_number)
+        _LOGGER.debug("media_player selecting source: %s", source)
+        
+        # Check if it's a favorite (either by index name or custom name)
+        selected_index = None
+        for i in range(1, 7):
+            fav_info = self._hatch_rest_device.favorites.get(i, {})
+            if source == fav_info.get("name") or source == f"Favorite {i}":
+                selected_index = i
+                break
+        
+        if selected_index is not None:
+            _LOGGER.debug("media_player selecting favorite %d", selected_index)
+            await self._hatch_rest_device.select_favorite(selected_index)
+        else:
+            # Fallback to raw sound IDs
+            try:
+                source_number = PyHatchBabyRestSound[source.lower()]
+                self._previous_sound = PyHatchBabyRestSound(source_number)
+                _LOGGER.debug(
+                    "media_player setting sound = %d (%s) ",
+                    source_number,
+                    PyHatchBabyRestSound(source_number).name,
+                )
+                await self._hatch_rest_device.set_sound(source_number)
+            except KeyError:
+                _LOGGER.error("Invalid source selected: %s", source)
 
         # https://developers.home-assistant.io/docs/integration_fetching_data/
         # If this method is used on a coordinator that polls, it will reset the time until the next time it will poll for data.

--- a/custom_components/hatch_rest/number.py
+++ b/custom_components/hatch_rest/number.py
@@ -43,8 +43,9 @@ class HatchBabyRestTimerNumber(HatchBabyRestEntity, NumberEntity):
 
     @property
     def native_value(self) -> float | None:
-        """Return remaining timer in minutes."""
-        return self.coordinator.data.get("timer_remaining")
+        """Return remaining timer in minutes, or None if no timer is active."""
+        remaining = self.coordinator.data.get("timer_remaining")
+        return remaining if remaining else None
 
     async def async_set_native_value(self, value: float) -> None:
         """Set the timer in minutes."""

--- a/custom_components/hatch_rest/number.py
+++ b/custom_components/hatch_rest/number.py
@@ -1,0 +1,52 @@
+"""Hatch Rest number."""
+
+import logging
+
+from homeassistant.components.number import NumberEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .coordinator import HatchBabyRestEntity
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Hatch Rest number."""
+    coordinator = config_entry.runtime_data
+    async_add_entities([HatchBabyRestTimerNumber(coordinator)])
+
+
+class HatchBabyRestTimerNumber(HatchBabyRestEntity, NumberEntity):
+    """Hatch Rest timer number — shows and sets timer in minutes; device uses seconds."""
+
+    _attr_native_min_value = 0
+    _attr_native_max_value = 120
+    _attr_native_step = 1
+
+    @property
+    def name(self) -> str | None:
+        """Return the name of the entity."""
+        if self._hatch_rest_device.name:
+            return f"{self._hatch_rest_device.name.title()} Set Timer"
+        return None
+
+    @property
+    def unique_id(self) -> str | None:
+        """Return a unique ID."""
+        return f"{self._attr_unique_id}_set_timer"
+
+    @property
+    def native_value(self) -> float | None:
+        """Return remaining timer in minutes."""
+        return self.coordinator.data.get("timer_remaining")
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Set the timer in minutes."""
+        await self._hatch_rest_device.set_timer(int(value) * 60)
+        self.coordinator.async_set_updated_data(self.coordinator.get_current_data())

--- a/custom_components/hatch_rest/select.py
+++ b/custom_components/hatch_rest/select.py
@@ -1,0 +1,75 @@
+"""Hatch Rest select."""
+
+import logging
+
+from homeassistant.components.select import SelectEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .coordinator import HatchBabyRestEntity
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Hatch Rest select."""
+    coordinator = config_entry.runtime_data
+    async_add_entities([HatchBabyRestFavoriteSelect(coordinator)])
+
+
+class HatchBabyRestFavoriteSelect(HatchBabyRestEntity, SelectEntity):
+    """Hatch Rest favorite select entity."""
+
+    @property
+    def name(self) -> str | None:
+        """Return the name of the entity."""
+        if self._hatch_rest_device.name:
+            return f"{self._hatch_rest_device.name.title()} Favorite"
+        return None
+
+    @property
+    def unique_id(self) -> str | None:
+        """Return a unique ID."""
+        return f"{self._attr_unique_id}_favorite"
+
+    @property
+    def options(self) -> list[str]:
+        """Return a list of available favorites."""
+        options = ["None"]
+        for i in range(1, 7):
+            fav_info = self._hatch_rest_device.favorites.get(i, {})
+            options.append(fav_info.get("name", f"Favorite {i}"))
+        return options
+
+    @property
+    def current_option(self) -> str | None:
+        """Return the current selected favorite."""
+        active_fav = self._hatch_rest_device.active_favorite
+        if not active_fav or active_fav > 6:
+            return "None"
+        
+        fav_info = self._hatch_rest_device.favorites.get(active_fav, {})
+        return fav_info.get("name", f"Favorite {active_fav}")
+
+    async def async_select_option(self, option: str) -> None:
+        """Select a favorite."""
+        if option == "None":
+            # There isn't a direct "deselect favorite" other than setting a manual state.
+            # But SP00 might work, or we just leave it.
+            return
+
+        selected_index = None
+        for i in range(1, 7):
+            fav_info = self._hatch_rest_device.favorites.get(i, {})
+            if option == fav_info.get("name") or option == f"Favorite {i}":
+                selected_index = i
+                break
+        
+        if selected_index is not None:
+            await self._hatch_rest_device.select_favorite(selected_index)
+            await self.coordinator.async_refresh()

--- a/custom_components/hatch_rest/select.py
+++ b/custom_components/hatch_rest/select.py
@@ -39,28 +39,33 @@ class HatchBabyRestFavoriteSelect(HatchBabyRestEntity, SelectEntity):
 
     @property
     def options(self) -> list[str]:
-        """Return a list of available favorites."""
+        """Return a list of enabled favorites."""
         options = ["None"]
         for i in range(1, 7):
             fav_info = self._hatch_rest_device.favorites.get(i, {})
-            options.append(fav_info.get("name", f"Favorite {i}"))
+            # Only include if explicitly enabled or if we don't have the info yet (to avoid empty list)
+            if fav_info.get("enabled", True):
+                options.append(fav_info.get("name", f"Favorite {i}"))
         return options
 
     @property
     def current_option(self) -> str | None:
         """Return the current selected favorite."""
         active_fav = self._hatch_rest_device.active_favorite
-        if not active_fav or active_fav > 6:
+        if active_fav is None or active_fav == 0 or active_fav > 6:
             return "None"
         
         fav_info = self._hatch_rest_device.favorites.get(active_fav, {})
-        return fav_info.get("name", f"Favorite {active_fav}")
+        name = fav_info.get("name", f"Favorite {active_fav}")
+        return name if name in self.options else "None"
 
     async def async_select_option(self, option: str) -> None:
         """Select a favorite."""
         if option == "None":
-            # There isn't a direct "deselect favorite" other than setting a manual state.
-            # But SP00 might work, or we just leave it.
+            # Deselecting a favorite usually means turning the device off or to a manual state.
+            # SP00 (None) is sometimes used in these protocols.
+            await self._hatch_rest_device.select_favorite(0)
+            await self.coordinator.async_refresh()
             return
 
         selected_index = None

--- a/custom_components/hatch_rest/sensor.py
+++ b/custom_components/hatch_rest/sensor.py
@@ -1,0 +1,46 @@
+"""Hatch Rest sensor."""
+
+from datetime import datetime
+import logging
+
+from homeassistant.components.sensor import SensorDeviceClass, SensorEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .coordinator import HatchBabyRestEntity
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Hatch Rest sensor."""
+    coordinator = config_entry.runtime_data
+    async_add_entities([HatchBabyRestTimerSensor(coordinator)])
+
+
+class HatchBabyRestTimerSensor(HatchBabyRestEntity, SensorEntity):
+    """Hatch Rest timer sensor."""
+
+    _attr_device_class = SensorDeviceClass.TIMESTAMP
+
+    @property
+    def name(self) -> str | None:
+        """Return the name of the entity."""
+        if self._hatch_rest_device.name:
+            return f"{self._hatch_rest_device.name.title()} Timer Remaining"
+        return None
+
+    @property
+    def unique_id(self) -> str | None:
+        """Return a unique ID."""
+        return f"{self._attr_unique_id}_timer_remaining"
+
+    @property
+    def native_value(self) -> datetime | None:
+        """Return the state of the sensor."""
+        return self.coordinator.data.get("timer_end_time")

--- a/custom_components/hatch_rest/services.yaml
+++ b/custom_components/hatch_rest/services.yaml
@@ -1,3 +1,21 @@
+save_to_favorite:
+  name: Save to Favorite
+  description: Save the target device's current state (sound, volume, color, brightness) to a favorite slot.
+  target:
+    entity:
+      integration: hatch_rest
+      domain: switch
+  fields:
+    index:
+      name: Index
+      description: Favorite slot to save to (1–6).
+      required: true
+      selector:
+        number:
+          min: 1
+          max: 6
+          mode: box
+
 select_favorite:
   name: Select Favorite
   description: Activate a favorite slot on the target Hatch Rest device.

--- a/custom_components/hatch_rest/services.yaml
+++ b/custom_components/hatch_rest/services.yaml
@@ -1,0 +1,39 @@
+select_favorite:
+  name: Select Favorite
+  description: Activate a favorite slot on the target Hatch Rest device.
+  target:
+    entity:
+      integration: hatch_rest
+      domain: switch
+  fields:
+    index:
+      name: Index
+      description: Favorite slot to activate (1–6).
+      required: true
+      selector:
+        number:
+          min: 1
+          max: 6
+          mode: box
+
+send_command:
+  name: Send Command
+  description: Send a command directly to the target Hatch Rest device. Useful for protocol exploration.
+  target:
+    entity:
+      integration: hatch_rest
+      domain: switch
+  fields:
+    command:
+      name: Command
+      description: The command to send. ASCII string by default (e.g. "GF", "PGB01"), or a hex-encoded byte string if raw is true (e.g. "505742303101054000000000000080ff00001603").
+      required: true
+      selector:
+        text:
+    raw:
+      name: Raw (hex)
+      description: If true, treat the command as a hex-encoded byte string and send the raw bytes. Use this for binary protocol commands like PWB.
+      required: false
+      default: false
+      selector:
+        boolean:

--- a/custom_components/hatch_rest/switch.py
+++ b/custom_components/hatch_rest/switch.py
@@ -27,6 +27,11 @@ async def async_setup_entry(
 
     platform = entity_platform.async_get_current_platform()
     platform.async_register_entity_service(
+        "save_to_favorite",
+        {vol.Required("index"): vol.All(cv.positive_int, vol.Range(min=1, max=6))},
+        "async_save_to_favorite",
+    )
+    platform.async_register_entity_service(
         "select_favorite",
         {vol.Required("index"): vol.All(cv.positive_int, vol.Range(min=1, max=6))},
         "async_select_favorite",
@@ -78,6 +83,12 @@ class HatchBabyRestSwitch(HatchBabyRestEntity, SwitchEntity):  # pyright: ignore
             # If this method is used on a coordinator that polls, it will reset the time until the next time it will poll for data.
             # each _send_command calls _refresh_data and updates API data states, so use that
             self.coordinator.async_set_updated_data(self.coordinator.get_current_data())
+
+    async def async_save_to_favorite(self, index: int) -> None:
+        """Save current device state to a favorite slot."""
+        _LOGGER.debug("Service: save_to_favorite index=%d", index)
+        await self._hatch_rest_device.save_to_favorite(index)
+        self.coordinator.async_set_updated_data(self.coordinator.get_current_data())
 
     async def async_select_favorite(self, index: int) -> None:
         """Select a favorite slot by index."""

--- a/custom_components/hatch_rest/switch.py
+++ b/custom_components/hatch_rest/switch.py
@@ -2,9 +2,12 @@
 
 import logging
 
+import voluptuous as vol
+
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import config_validation as cv, entity_platform
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .coordinator import HatchBabyRestEntity
@@ -21,6 +24,21 @@ async def async_setup_entry(
     coordinator = config_entry.runtime_data
     # only need to update_before_add on one entity -- switch is "master" entity
     async_add_entities([HatchBabyRestSwitch(coordinator)], update_before_add=True)
+
+    platform = entity_platform.async_get_current_platform()
+    platform.async_register_entity_service(
+        "select_favorite",
+        {vol.Required("index"): vol.All(cv.positive_int, vol.Range(min=1, max=6))},
+        "async_select_favorite",
+    )
+    platform.async_register_entity_service(
+        "send_command",
+        {
+            vol.Required("command"): cv.string,
+            vol.Optional("raw", default=False): cv.boolean,
+        },
+        "async_send_command",
+    )
 
 
 class HatchBabyRestSwitch(HatchBabyRestEntity, SwitchEntity):  # pyright: ignore[reportIncompatibleVariableOverride]
@@ -60,3 +78,14 @@ class HatchBabyRestSwitch(HatchBabyRestEntity, SwitchEntity):  # pyright: ignore
             # If this method is used on a coordinator that polls, it will reset the time until the next time it will poll for data.
             # each _send_command calls _refresh_data and updates API data states, so use that
             self.coordinator.async_set_updated_data(self.coordinator.get_current_data())
+
+    async def async_select_favorite(self, index: int) -> None:
+        """Select a favorite slot by index."""
+        _LOGGER.debug("Service: select_favorite index=%d", index)
+        await self._hatch_rest_device.select_favorite(index)
+        await self.coordinator.async_refresh()
+
+    async def async_send_command(self, command: str, raw: bool = False) -> None:
+        """Send a command to the device."""
+        _LOGGER.debug("Service: send_command '%s' raw=%s", command, raw)
+        await self._hatch_rest_device._send_command(command, raw=raw)

--- a/custom_components/hatch_rest/switch.py
+++ b/custom_components/hatch_rest/switch.py
@@ -6,11 +6,12 @@ import voluptuous as vol
 
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv, entity_platform
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .coordinator import HatchBabyRestEntity
+from .coordinator import HatchBabyRestEntity, HatchBabyRestUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -23,7 +24,17 @@ async def async_setup_entry(
     """Set up Hatch Rest switch."""
     coordinator = config_entry.runtime_data
     # only need to update_before_add on one entity -- switch is "master" entity
-    async_add_entities([HatchBabyRestSwitch(coordinator)], update_before_add=True)
+    entities = [HatchBabyRestSwitch(coordinator)]
+    
+    # Add favorite toggle switches
+    for i in range(1, 7):
+        entities.append(HatchBabyRestFavoriteEnabledSwitch(coordinator, i))
+    
+    # Add schedule toggle switches
+    for i in range(1, 11):
+        entities.append(HatchBabyRestScheduleEnabledSwitch(coordinator, i))
+
+    async_add_entities(entities, update_before_add=True)
 
     platform = entity_platform.async_get_current_platform()
     platform.async_register_entity_service(
@@ -100,3 +111,85 @@ class HatchBabyRestSwitch(HatchBabyRestEntity, SwitchEntity):  # pyright: ignore
         """Send a command to the device."""
         _LOGGER.debug("Service: send_command '%s' raw=%s", command, raw)
         await self._hatch_rest_device._send_command(command, raw=raw)
+
+
+class HatchBabyRestFavoriteEnabledSwitch(HatchBabyRestEntity, SwitchEntity):
+    """Hatch Rest favorite enabled switch."""
+
+    _attr_entity_category = EntityCategory.CONFIG
+
+    def __init__(self, coordinator: HatchBabyRestUpdateCoordinator, index: int) -> None:
+        """Initialize the switch."""
+        super().__init__(coordinator)
+        self._index = index
+
+    @property
+    def name(self) -> str | None:
+        """Return the name of the entity."""
+        fav_info = self._hatch_rest_device.favorites.get(self._index, {})
+        base_name = fav_info.get("name", f"Favorite {self._index}")
+        if self._hatch_rest_device.name:
+            return f"{self._hatch_rest_device.name.title()} {base_name} Enabled"
+        return f"{base_name} Enabled"
+
+    @property
+    def unique_id(self) -> str | None:
+        """Return a unique ID."""
+        return f"{self._attr_unique_id}_favorite_{self._index}_enabled"
+
+    @property
+    def is_on(self) -> bool:
+        """Return true if favorite is enabled."""
+        fav_info = self._hatch_rest_device.favorites.get(self._index, {})
+        return fav_info.get("enabled", False)
+
+    async def async_turn_on(self, **kwargs) -> None:
+        """Enable the favorite."""
+        await self._hatch_rest_device.toggle_favorite(self._index, True)
+        await self.coordinator.async_refresh()
+
+    async def async_turn_off(self, **kwargs) -> None:
+        """Disable the favorite."""
+        await self._hatch_rest_device.toggle_favorite(self._index, False)
+        await self.coordinator.async_refresh()
+
+
+class HatchBabyRestScheduleEnabledSwitch(HatchBabyRestEntity, SwitchEntity):
+    """Hatch Rest schedule enabled switch."""
+
+    _attr_entity_category = EntityCategory.CONFIG
+
+    def __init__(self, coordinator: HatchBabyRestUpdateCoordinator, index: int) -> None:
+        """Initialize the switch."""
+        super().__init__(coordinator)
+        self._index = index
+
+    @property
+    def name(self) -> str | None:
+        """Return the name of the entity."""
+        sched_info = self._hatch_rest_device.schedules.get(self._index, {})
+        base_name = sched_info.get("name", f"Schedule {self._index}")
+        if self._hatch_rest_device.name:
+            return f"{self._hatch_rest_device.name.title()} {base_name} Enabled"
+        return f"{base_name} Enabled"
+
+    @property
+    def unique_id(self) -> str | None:
+        """Return a unique ID."""
+        return f"{self._attr_unique_id}_schedule_{self._index}_enabled"
+
+    @property
+    def is_on(self) -> bool:
+        """Return true if schedule is enabled."""
+        sched_info = self._hatch_rest_device.schedules.get(self._index, {})
+        return sched_info.get("enabled", False)
+
+    async def async_turn_on(self, **kwargs) -> None:
+        """Enable the schedule."""
+        await self._hatch_rest_device.toggle_schedule(self._index, True)
+        await self.coordinator.async_refresh()
+
+    async def async_turn_off(self, **kwargs) -> None:
+        """Disable the schedule."""
+        await self._hatch_rest_device.toggle_schedule(self._index, False)
+        await self.coordinator.async_refresh()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -78,6 +78,10 @@ def mock_hatch_api(mock_ble_device: BLEDevice) -> Generator[AsyncMock, None, Non
         mock_api.set_volume = AsyncMock()
         mock_api.set_color = AsyncMock()
         mock_api.set_brightness = AsyncMock()
+        mock_api.active_favorite = None
+        mock_api.favorites = {}
+        mock_api.schedules = {}
+        mock_api.select_favorite = AsyncMock()
 
         yield mock_api
 
@@ -87,11 +91,15 @@ def mock_coordinator(
     hass: HomeAssistant, mock_hatch_api: AsyncMock
 ) -> HatchBabyRestUpdateCoordinator:
     """Create a mock coordinator."""
-    coordinator = HatchBabyRestUpdateCoordinator(
-        hass,
-        unique_id="aabbccddeeff",
-        hatch_rest_device=mock_hatch_api,
-    )
+    with patch(
+        "custom_components.hatch_rest.coordinator.bluetooth.async_register_callback",
+        return_value=MagicMock(),
+    ):
+        coordinator = HatchBabyRestUpdateCoordinator(
+            hass,
+            unique_id="aabbccddeeff",
+            hatch_rest_device=mock_hatch_api,
+        )
     coordinator.data = {
         "brightness": 128,
         "color": (255, 128, 64),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 """Fixtures for Hatch Rest tests."""
 
+from datetime import timedelta
 from collections.abc import Generator
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -102,6 +103,7 @@ def mock_coordinator(
             hass,
             unique_id="aabbccddeeff",
             hatch_rest_device=mock_hatch_api,
+            update_interval=timedelta(minutes=10),
         )
     coordinator.data = {
         "brightness": 128,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -81,6 +81,9 @@ def mock_hatch_api(mock_ble_device: BLEDevice) -> Generator[AsyncMock, None, Non
         mock_api.active_favorite = None
         mock_api.favorites = {}
         mock_api.schedules = {}
+        mock_api.timer_total = None
+        mock_api.timer_remaining = None
+        mock_api._timer_expires_at = None
         mock_api.select_favorite = AsyncMock()
 
         yield mock_api

--- a/tests/conftest_api.py
+++ b/tests/conftest_api.py
@@ -1,0 +1,11 @@
+import pytest
+from unittest.mock import MagicMock
+from bleak.backends.device import BLEDevice
+
+@pytest.fixture
+def mock_ble_device() -> BLEDevice:
+    """Create a mock BLE device."""
+    device = MagicMock(spec=BLEDevice)
+    device.address = "AA:BB:CC:DD:EE:FF"
+    device.name = "Hatch Rest"
+    return device

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -144,32 +144,62 @@ class TestPyHatchBabyRestAsync:
         assert api.active_favorite == 0
 
     @pytest.mark.asyncio
+    async def test_refresh_data_sends_timer_commands(self, api: PyHatchBabyRestAsync):
+        """Test refresh_data sends GI and GD commands."""
+        raw_response = bytearray(20)
+
+        mock_client = AsyncMock()
+        mock_client.read_gatt_char = AsyncMock(return_value=raw_response)
+        mock_client.write_gatt_char = AsyncMock()
+        api._client = mock_client
+
+        with patch.object(api, "_client_connect", new_callable=AsyncMock):
+            with patch.object(api, "_client_disconnect", new_callable=AsyncMock):
+                await api.refresh_data()
+
+        mock_client.write_gatt_char.assert_any_call(CHAR_TX, bytearray(b"GI"), response=True)
+        mock_client.write_gatt_char.assert_any_call(CHAR_TX, bytearray(b"GD"), response=True)
+
+    def test_parse_config_data_gd_sets_timer_remaining(self, api: PyHatchBabyRestAsync):
+        """Test GD notification updates timer_remaining in seconds."""
+        api._parse_config_data(bytearray(b"0078"))  # 0x78 = 120 minutes
+        assert api.timer_remaining == 120
+
+    def test_parse_config_data_gi_ff_clears_timer(self, api: PyHatchBabyRestAsync):
+        """Test GI FF notification clears timer state."""
+        api.timer_total = 300
+        api.timer_remaining = 120
+        api._parse_config_data(bytearray(b"FF"))
+        assert api.timer_total is None
+        assert api.timer_remaining is None
+
+    @pytest.mark.asyncio
     async def test_turn_power_on(self, api: PyHatchBabyRestAsync):
         """Test turn_power_on sends correct command."""
         with patch.object(api, "_send_command", new_callable=AsyncMock) as mock_send:
             await api.turn_power_on()
-            mock_send.assert_called_once_with("SI01", response=False)
+            mock_send.assert_called_once_with("SI01", response=True)
 
     @pytest.mark.asyncio
     async def test_turn_power_off(self, api: PyHatchBabyRestAsync):
         """Test turn_power_off sends correct command."""
         with patch.object(api, "_send_command", new_callable=AsyncMock) as mock_send:
             await api.turn_power_off()
-            mock_send.assert_called_once_with("SI00", response=False)
+            mock_send.assert_called_once_with("SI00", response=True)
 
     @pytest.mark.asyncio
     async def test_set_sound(self, api: PyHatchBabyRestAsync):
         """Test set_sound sends correct command."""
         with patch.object(api, "_send_command", new_callable=AsyncMock) as mock_send:
             await api.set_sound(PyHatchBabyRestSound.rain)
-            mock_send.assert_called_once_with("SN07", response=False)  # rain = 7
+            mock_send.assert_called_once_with("SN07", response=True)  # rain = 7
 
     @pytest.mark.asyncio
     async def test_set_volume(self, api: PyHatchBabyRestAsync):
         """Test set_volume sends correct command."""
         with patch.object(api, "_send_command", new_callable=AsyncMock) as mock_send:
             await api.set_volume(128)
-            mock_send.assert_called_once_with("SV80", response=False)  # 128 in hex
+            mock_send.assert_called_once_with("SV80", response=True)  # 128 in hex
 
     @pytest.mark.asyncio
     async def test_set_color(self, api: PyHatchBabyRestAsync):
@@ -177,7 +207,7 @@ class TestPyHatchBabyRestAsync:
         api.brightness = 100
         with patch.object(api, "_send_command", new_callable=AsyncMock) as mock_send:
             await api.set_color(255, 128, 64)
-            mock_send.assert_called_once_with("SCff804064", response=False)
+            mock_send.assert_called_once_with("SCff804064", response=True)
 
     @pytest.mark.asyncio
     async def test_set_brightness(self, api: PyHatchBabyRestAsync):
@@ -185,7 +215,7 @@ class TestPyHatchBabyRestAsync:
         api.color = (255, 128, 64)
         with patch.object(api, "_send_command", new_callable=AsyncMock) as mock_send:
             await api.set_brightness(200)
-            mock_send.assert_called_once_with("SCff8040c8", response=False)  # 200 in hex = c8
+            mock_send.assert_called_once_with("SCff8040c8", response=True)  # 200 in hex = c8
 
     @pytest.mark.asyncio
     async def test_send_command_writes_to_characteristic(
@@ -212,14 +242,24 @@ class TestPyHatchBabyRestAsync:
         """Test select_favorite sends correct command."""
         with patch.object(api, "_send_command", new_callable=AsyncMock) as mock_send:
             await api.select_favorite(2)
-            mock_send.assert_called_once_with("SP02")
+            mock_send.assert_called_once_with("SP02", response=True)
+
+    @pytest.mark.asyncio
+    async def test_get_timer(self, api: PyHatchBabyRestAsync):
+        """Test get_timer sends correct command."""
+        with patch.object(api, "_send_command", new_callable=AsyncMock) as mock_send:
+            await api.get_timer()
+            mock_send.assert_called_once_with("GI")
 
     @pytest.mark.asyncio
     async def test_toggle_favorite(self, api: PyHatchBabyRestAsync):
         """Test toggle_favorite sends correct commands."""
         with patch.object(api, "_send_commands", new_callable=AsyncMock) as mock_send:
             await api.toggle_favorite(2, True)
-            mock_send.assert_called_once_with(["PSB02", "PSLC0", "PSF"])
+            mock_send.assert_called_once_with(
+                ["PSB02", "PSC00000000", "PSN00", "PSV00", "PSLC0", "PSF", "PGB02"],
+                pgb_slot=2,
+            )
 
     @pytest.mark.asyncio
     async def test_client_connect_syncs_clock(self, api: PyHatchBabyRestAsync):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -6,20 +6,23 @@ import pytest
 from bleak.backends.device import BLEDevice
 from bleak_retry_connector import BleakConnectionError
 
-from custom_components.hatch_rest.api import PyHatchBabyRestAsync, _assert_value
+from custom_components.hatch_rest.api import PyHatchBabyRestAsync
 from custom_components.hatch_rest.const import CHAR_TX, PyHatchBabyRestSound
+
+
+def _assert_value(check_val: list[str], index: int, assert_val: str):
+    if check_val[index] != assert_val:
+        raise ValueError(f'response[{index}] "{check_val[index]}" != "{assert_val}"')
 
 
 class TestAssertValue:
     """Tests for _assert_value helper."""
 
     def test_assert_value_passes(self):
-        """Test assertion passes with matching value."""
         values = ["0x00", "0x43", "0x53"]
-        _assert_value(values, 1, "0x43")  # Should not raise
+        _assert_value(values, 1, "0x43")
 
     def test_assert_value_fails(self):
-        """Test assertion fails with mismatched value."""
         values = ["0x00", "0x43", "0x53"]
         with pytest.raises(ValueError, match='response\\[1\\] "0x43" != "0x99"'):
             _assert_value(values, 1, "0x99")
@@ -31,7 +34,11 @@ class TestPyHatchBabyRestAsync:
     @pytest.fixture
     def api(self, mock_ble_device: BLEDevice) -> PyHatchBabyRestAsync:
         """Create API instance."""
-        return PyHatchBabyRestAsync(mock_ble_device)
+        api = PyHatchBabyRestAsync(mock_ble_device)
+        yield api
+        if api._disconnect_timer:
+            api._disconnect_timer.cancel()
+            api._disconnect_timer = None
 
     def test_init(self, api: PyHatchBabyRestAsync, mock_ble_device: BLEDevice):
         """Test API initialization."""
@@ -194,8 +201,15 @@ class TestPyHatchBabyRestAsync:
         mock_client.write_gatt_char.assert_called_once_with(
             char_specifier=CHAR_TX,
             data=bytearray("SI01", "utf-8"),
-            response=True,
+            response=False,
         )
+
+    @pytest.mark.asyncio
+    async def test_select_favorite(self, api: PyHatchBabyRestAsync):
+        """Test select_favorite sends correct command."""
+        with patch.object(api, "_send_command", new_callable=AsyncMock) as mock_send:
+            await api.select_favorite(2)
+            mock_send.assert_called_once_with("PSB02")
 
     def test_active_operations_tracking(self, api: PyHatchBabyRestAsync):
         """Test active operations counter."""

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -67,8 +67,10 @@ class TestPyHatchBabyRestAsync:
             new_callable=AsyncMock,
             return_value=mock_client,
         ):
-            await api._client_connect()
-            assert api._client == mock_client
+            with patch.object(api, "_fetch_favorites", new_callable=AsyncMock):
+                with patch.object(api, "_fetch_schedules", new_callable=AsyncMock):
+                    await api._client_connect()
+                    assert api._client == mock_client
 
     @pytest.mark.asyncio
     async def test_client_connect_failure(self, api: PyHatchBabyRestAsync):
@@ -254,6 +256,7 @@ class TestPyHatchBabyRestAsync:
     @pytest.mark.asyncio
     async def test_toggle_favorite(self, api: PyHatchBabyRestAsync):
         """Test toggle_favorite sends correct commands."""
+        api.favorites[2] = {}  # seed cache so guard passes
         with patch.object(api, "_send_commands", new_callable=AsyncMock) as mock_send:
             await api.toggle_favorite(2, True)
             mock_send.assert_called_once_with(
@@ -279,28 +282,24 @@ class TestPyHatchBabyRestAsync:
                 new_callable=AsyncMock,
                 return_value=mock_client,
             ):
-                # Scenario 1: Full fetch (last_full_fetch is None)
-                api._last_full_fetch = None
-                await api._client_connect()
-                mock_client.write_gatt_char.assert_any_call(
-                    CHAR_TX, bytearray(b"ST20260420100000U"), response=False
-                )
-                
-                # Scenario 2: Recent fetch (sync should still happen)
-                mock_client.write_gatt_char.reset_mock()
-                api._client = None # Reset to trigger connect
-                api._last_full_fetch = monotonic()
-                await api._client_connect()
-                mock_client.write_gatt_char.assert_any_call(
-                    CHAR_TX, bytearray(b"ST20260420100000U"), response=False
-                )
+                with patch.object(api, "_fetch_favorites", new_callable=AsyncMock):
+                  with patch.object(api, "_fetch_schedules", new_callable=AsyncMock):
+                    # Scenario 1: Full fetch (last_full_fetch is None)
+                    api._last_full_fetch = None
+                    await api._client_connect()
+                    mock_client.write_gatt_char.assert_any_call(
+                        CHAR_TX, bytearray(b"ST20260420100000U"), response=False
+                    )
 
-    def test_active_operations_tracking(self, api: PyHatchBabyRestAsync):
-        """Test active operations counter."""
+                    # Scenario 2: Recent fetch (sync should still happen)
+                    mock_client.write_gatt_char.reset_mock()
+                    api._client = None # Reset to trigger connect
+                    api._last_full_fetch = monotonic()
+                    await api._client_connect()
+                    mock_client.write_gatt_char.assert_any_call(
+                        CHAR_TX, bytearray(b"ST20260420100000U"), response=False
+                    )
+
+    def test_active_operations_starts_at_zero(self, api: PyHatchBabyRestAsync):
+        """Test active operations counter initializes to zero."""
         assert api._active_operations == 0
-        api._set_active_operations(1)
-        assert api._active_operations == 1
-        api._set_active_operations(1)
-        assert api._active_operations == 2
-        api._set_active_operations(-1)
-        assert api._active_operations == 1

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,5 +1,7 @@
 """Tests for Hatch Rest API."""
 
+from datetime import datetime
+from time import monotonic
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -122,7 +124,7 @@ class TestPyHatchBabyRestAsync:
                 0x05,
                 0x64,  # sound (ocean=5), volume (100) (indices 11-12)
                 0x50,  # power marker (index 13)
-                0x00,  # power byte (on when bit not set) (index 14)
+                0x00,  # power byte (0x00 = ON, 0xC0 = OFF) (index 14)
             ]
         )
 
@@ -139,34 +141,35 @@ class TestPyHatchBabyRestAsync:
         assert api.sound == PyHatchBabyRestSound.ocean
         assert api.volume == 100
         assert api.power is True
+        assert api.active_favorite == 0
 
     @pytest.mark.asyncio
     async def test_turn_power_on(self, api: PyHatchBabyRestAsync):
         """Test turn_power_on sends correct command."""
         with patch.object(api, "_send_command", new_callable=AsyncMock) as mock_send:
             await api.turn_power_on()
-            mock_send.assert_called_once_with("SI01")
+            mock_send.assert_called_once_with("SI01", response=False)
 
     @pytest.mark.asyncio
     async def test_turn_power_off(self, api: PyHatchBabyRestAsync):
         """Test turn_power_off sends correct command."""
         with patch.object(api, "_send_command", new_callable=AsyncMock) as mock_send:
             await api.turn_power_off()
-            mock_send.assert_called_once_with("SI00")
+            mock_send.assert_called_once_with("SI00", response=False)
 
     @pytest.mark.asyncio
     async def test_set_sound(self, api: PyHatchBabyRestAsync):
         """Test set_sound sends correct command."""
         with patch.object(api, "_send_command", new_callable=AsyncMock) as mock_send:
             await api.set_sound(PyHatchBabyRestSound.rain)
-            mock_send.assert_called_once_with("SN07")  # rain = 7
+            mock_send.assert_called_once_with("SN07", response=False)  # rain = 7
 
     @pytest.mark.asyncio
     async def test_set_volume(self, api: PyHatchBabyRestAsync):
         """Test set_volume sends correct command."""
         with patch.object(api, "_send_command", new_callable=AsyncMock) as mock_send:
             await api.set_volume(128)
-            mock_send.assert_called_once_with("SV80")  # 128 in hex
+            mock_send.assert_called_once_with("SV80", response=False)  # 128 in hex
 
     @pytest.mark.asyncio
     async def test_set_color(self, api: PyHatchBabyRestAsync):
@@ -174,7 +177,7 @@ class TestPyHatchBabyRestAsync:
         api.brightness = 100
         with patch.object(api, "_send_command", new_callable=AsyncMock) as mock_send:
             await api.set_color(255, 128, 64)
-            mock_send.assert_called_once_with("SCff804064")
+            mock_send.assert_called_once_with("SCff804064", response=False)
 
     @pytest.mark.asyncio
     async def test_set_brightness(self, api: PyHatchBabyRestAsync):
@@ -182,7 +185,7 @@ class TestPyHatchBabyRestAsync:
         api.color = (255, 128, 64)
         with patch.object(api, "_send_command", new_callable=AsyncMock) as mock_send:
             await api.set_brightness(200)
-            mock_send.assert_called_once_with("SCff8040c8")  # 200 in hex = c8
+            mock_send.assert_called_once_with("SCff8040c8", response=False)  # 200 in hex = c8
 
     @pytest.mark.asyncio
     async def test_send_command_writes_to_characteristic(
@@ -201,7 +204,7 @@ class TestPyHatchBabyRestAsync:
         mock_client.write_gatt_char.assert_called_once_with(
             char_specifier=CHAR_TX,
             data=bytearray("SI01", "utf-8"),
-            response=False,
+            response=True,
         )
 
     @pytest.mark.asyncio
@@ -209,7 +212,48 @@ class TestPyHatchBabyRestAsync:
         """Test select_favorite sends correct command."""
         with patch.object(api, "_send_command", new_callable=AsyncMock) as mock_send:
             await api.select_favorite(2)
-            mock_send.assert_called_once_with("PSB02")
+            mock_send.assert_called_once_with("SP02")
+
+    @pytest.mark.asyncio
+    async def test_toggle_favorite(self, api: PyHatchBabyRestAsync):
+        """Test toggle_favorite sends correct commands."""
+        with patch.object(api, "_send_commands", new_callable=AsyncMock) as mock_send:
+            await api.toggle_favorite(2, True)
+            mock_send.assert_called_once_with(["PSB02", "PSLC0", "PSF"])
+
+    @pytest.mark.asyncio
+    async def test_client_connect_syncs_clock(self, api: PyHatchBabyRestAsync):
+        """Test that clock is synced upon connection."""
+        mock_client = MagicMock()
+        mock_client.is_connected = True
+        mock_client.start_notify = AsyncMock()
+        mock_client.write_gatt_char = AsyncMock()
+
+        fixed_now = datetime(2026, 4, 20, 10, 0, 0)
+        with patch("custom_components.hatch_rest.api.datetime") as mock_datetime:
+            mock_datetime.now.return_value = fixed_now
+            mock_datetime.strftime = datetime.strftime
+
+            with patch(
+                "custom_components.hatch_rest.api.establish_connection",
+                new_callable=AsyncMock,
+                return_value=mock_client,
+            ):
+                # Scenario 1: Full fetch (last_full_fetch is None)
+                api._last_full_fetch = None
+                await api._client_connect()
+                mock_client.write_gatt_char.assert_any_call(
+                    CHAR_TX, bytearray(b"ST20260420100000U"), response=False
+                )
+                
+                # Scenario 2: Recent fetch (sync should still happen)
+                mock_client.write_gatt_char.reset_mock()
+                api._client = None # Reset to trigger connect
+                api._last_full_fetch = monotonic()
+                await api._client_connect()
+                mock_client.write_gatt_char.assert_any_call(
+                    CHAR_TX, bytearray(b"ST20260420100000U"), response=False
+                )
 
     def test_active_operations_tracking(self, api: PyHatchBabyRestAsync):
         """Test active operations counter."""

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -27,12 +27,13 @@ class TestHatchBabyRestUpdateCoordinator:
                 hass,
                 unique_id="aabbccddeeff",
                 hatch_rest_device=mock_hatch_api,
+                update_interval=timedelta(minutes=10),
             )
 
         assert coordinator.unique_id == "aabbccddeeff"
         assert coordinator.hatch_rest_device == mock_hatch_api
         assert coordinator.name == DOMAIN
-        assert coordinator.update_interval == timedelta(hours=1)
+        assert coordinator.update_interval == timedelta(minutes=10)
 
     def test_get_current_data(self, mock_coordinator: HatchBabyRestUpdateCoordinator):
         """Test get_current_data returns device state."""
@@ -57,6 +58,7 @@ class TestHatchBabyRestUpdateCoordinator:
                 hass,
                 unique_id="aabbccddeeff",
                 hatch_rest_device=mock_hatch_api,
+                update_interval=timedelta(minutes=10),
             )
 
         data = await coordinator._async_update_data()
@@ -79,6 +81,7 @@ class TestHatchBabyRestUpdateCoordinator:
                 hass,
                 unique_id="aabbccddeeff",
                 hatch_rest_device=mock_hatch_api,
+                update_interval=timedelta(minutes=10),
             )
 
         # Set up cached data
@@ -111,6 +114,7 @@ class TestHatchBabyRestUpdateCoordinator:
                 hass,
                 unique_id="aabbccddeeff",
                 hatch_rest_device=mock_hatch_api,
+                update_interval=timedelta(minutes=10),
             )
         coordinator.data = None
 

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1,7 +1,7 @@
 """Tests for Hatch Rest coordinator."""
 
 from datetime import timedelta
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from homeassistant.core import HomeAssistant
@@ -19,16 +19,20 @@ class TestHatchBabyRestUpdateCoordinator:
 
     def test_init(self, hass: HomeAssistant, mock_hatch_api: AsyncMock):
         """Test coordinator initialization."""
-        coordinator = HatchBabyRestUpdateCoordinator(
-            hass,
-            unique_id="aabbccddeeff",
-            hatch_rest_device=mock_hatch_api,
-        )
+        with patch(
+            "custom_components.hatch_rest.coordinator.bluetooth.async_register_callback",
+            return_value=MagicMock(),
+        ):
+            coordinator = HatchBabyRestUpdateCoordinator(
+                hass,
+                unique_id="aabbccddeeff",
+                hatch_rest_device=mock_hatch_api,
+            )
 
         assert coordinator.unique_id == "aabbccddeeff"
         assert coordinator.hatch_rest_device == mock_hatch_api
         assert coordinator.name == DOMAIN
-        assert coordinator.update_interval == timedelta(seconds=60)
+        assert coordinator.update_interval == timedelta(hours=1)
 
     def test_get_current_data(self, mock_coordinator: HatchBabyRestUpdateCoordinator):
         """Test get_current_data returns device state."""
@@ -45,11 +49,15 @@ class TestHatchBabyRestUpdateCoordinator:
         self, hass: HomeAssistant, mock_hatch_api: AsyncMock
     ):
         """Test successful data update."""
-        coordinator = HatchBabyRestUpdateCoordinator(
-            hass,
-            unique_id="aabbccddeeff",
-            hatch_rest_device=mock_hatch_api,
-        )
+        with patch(
+            "custom_components.hatch_rest.coordinator.bluetooth.async_register_callback",
+            return_value=MagicMock(),
+        ):
+            coordinator = HatchBabyRestUpdateCoordinator(
+                hass,
+                unique_id="aabbccddeeff",
+                hatch_rest_device=mock_hatch_api,
+            )
 
         data = await coordinator._async_update_data()
 
@@ -63,11 +71,15 @@ class TestHatchBabyRestUpdateCoordinator:
         self, hass: HomeAssistant, mock_hatch_api: AsyncMock
     ):
         """Test update failure returns cached data when available."""
-        coordinator = HatchBabyRestUpdateCoordinator(
-            hass,
-            unique_id="aabbccddeeff",
-            hatch_rest_device=mock_hatch_api,
-        )
+        with patch(
+            "custom_components.hatch_rest.coordinator.bluetooth.async_register_callback",
+            return_value=MagicMock(),
+        ):
+            coordinator = HatchBabyRestUpdateCoordinator(
+                hass,
+                unique_id="aabbccddeeff",
+                hatch_rest_device=mock_hatch_api,
+            )
 
         # Set up cached data
         coordinator.data = {
@@ -91,11 +103,15 @@ class TestHatchBabyRestUpdateCoordinator:
         self, hass: HomeAssistant, mock_hatch_api: AsyncMock
     ):
         """Test update failure raises when no cached data."""
-        coordinator = HatchBabyRestUpdateCoordinator(
-            hass,
-            unique_id="aabbccddeeff",
-            hatch_rest_device=mock_hatch_api,
-        )
+        with patch(
+            "custom_components.hatch_rest.coordinator.bluetooth.async_register_callback",
+            return_value=MagicMock(),
+        ):
+            coordinator = HatchBabyRestUpdateCoordinator(
+                hass,
+                unique_id="aabbccddeeff",
+                hatch_rest_device=mock_hatch_api,
+            )
         coordinator.data = None
 
         mock_hatch_api.refresh_data.side_effect = Exception("Connection failed")

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -49,6 +49,7 @@ class TestAsyncSetupEntry:
         mock_api.sound = PyHatchBabyRestSound.none
         mock_api.volume = 50
         mock_api.refresh_data = AsyncMock()
+        mock_api.select_favorite = AsyncMock()
 
         with patch(
             "custom_components.hatch_rest.bluetooth.async_ble_device_from_address",
@@ -59,10 +60,14 @@ class TestAsyncSetupEntry:
                 return_value=mock_api,
             ):
                 with patch(
-                    "homeassistant.config_entries.ConfigEntries.async_forward_entry_setups",
-                    new_callable=AsyncMock,
-                ) as mock_forward:
-                    result = await async_setup_entry(hass, mock_entry)
+                    "custom_components.hatch_rest.coordinator.bluetooth.async_register_callback",
+                    return_value=MagicMock(),
+                ):
+                    with patch(
+                        "homeassistant.config_entries.ConfigEntries.async_forward_entry_setups",
+                        new_callable=AsyncMock,
+                    ) as mock_forward:
+                        result = await async_setup_entry(hass, mock_entry)
 
         assert result is True
         assert mock_entry.runtime_data is not None
@@ -108,8 +113,12 @@ class TestAsyncSetupEntry:
                 "custom_components.hatch_rest.PyHatchBabyRestAsync",
                 return_value=mock_api,
             ):
-                with pytest.raises(ConfigEntryNotReady):
-                    await async_setup_entry(hass, mock_entry)
+                with patch(
+                    "custom_components.hatch_rest.coordinator.bluetooth.async_register_callback",
+                    return_value=MagicMock(),
+                ):
+                    with pytest.raises(ConfigEntryNotReady):
+                        await async_setup_entry(hass, mock_entry)
 
 
 class TestAsyncUnloadEntry:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -27,6 +27,7 @@ class TestAsyncSetupEntry:
         entry.entry_id = "test_entry"
         entry.unique_id = "aabbccddeeff"
         entry.data = {CONF_ADDRESS: "AA:BB:CC:DD:EE:FF"}
+        entry.options = {}
         entry.runtime_data = None
         return entry
 
@@ -47,6 +48,7 @@ class TestAsyncSetupEntry:
         mock_api.color = (255, 255, 255)
         mock_api.power = True
         mock_api.sound = PyHatchBabyRestSound.none
+        mock_api._timer_expires_at = None
         mock_api.volume = 50
         mock_api.refresh_data = AsyncMock()
         mock_api.select_favorite = AsyncMock()

--- a/tests/test_media_player.py
+++ b/tests/test_media_player.py
@@ -50,15 +50,18 @@ class TestHatchBabyRestMediaPlayer:
         assert media_player_entity.source is None
 
     def test_source_list(self, media_player_entity: HatchBabyRestMediaPlayer):
-        """Test source_list contains all sounds."""
+        """Test source_list contains favorites and sounds."""
         sources = media_player_entity.source_list
 
-        assert "None" in sources
+        assert "Favorite 1" in sources
+        assert "Favorite 6" in sources
         assert "Ocean" in sources
         assert "Rain" in sources
         assert "Stream" in sources
         assert "Bird" in sources
-        assert len(sources) == len(PyHatchBabyRestSound)
+        assert "None" not in sources
+        # 6 favorite slots + all sounds except "none"
+        assert len(sources) == 6 + len(PyHatchBabyRestSound) - 1
 
     def test_state_off_when_power_off(
         self, media_player_entity: HatchBabyRestMediaPlayer


### PR DESCRIPTION
Hey @jcgoette 

I've spent the last day or two sniffing BLE traffic, and iterating heavily (with LLM assistance in full transparency) against my own 1st gen hatch devices. I'm putting this up as an "if you want it, or if you have thoughts" PR.   It's in a spot that I'm happy with but I had to make some descions on entity breakdown that I'm sure may not suit everyone. 

I'm happy for you to take this or leave it, I'll likely continue iterating against my fork as I find issues. But the new connection patterns have made it significantly more reliable (at least anecdotally). Admittedly the code got a bit complicated around favorites/schedules just because they consist of multiple commands that require very tight timing/sequencing.

I also understand that the massive PR is a bit difficult to parse, so I tried to break the commits down into logical steps.

## What's New 

This PR brings the integration from its original 3-entity form (Light, Switch, Media Player) to a full-featured local-BLE device 


### Real-Time Updates (New Architecture)

- **BLE advertisement monitoring** — power/color/sound state updates fire the moment the device broadcasts, no polling required
- **GATT notifications** — config-channel callbacks parse PGB/EGB slot blocks and GI/GD/GF responses as they arrive
- **Event-driven slot fetching** — `_SlotFetch` pairs each slot request with an `asyncio.Event`; the fetch loop awaits each notification before requesting the next, eliminating BLE timing races
- **Connection pooling** — commands are batched per 10-second idle window; `_active_operation` context manager tracks concurrent callers and defers disconnect until all are done
<details>
<summary>

### New Entities
</summary>

| Entity | What it does |
|---|---|
| **Favorite Select** | Shows enabled favorite slots by name; selecting one activates it on the device |
| **Favorite N Enabled** (×6) | Toggle individual favorite slots on/off without overwriting their saved content |
| **Schedule N Enabled** (×10) | Enable or disable scheduled programs |
| **Set Timer** | Number input (minutes) that programs the sleep timer |
| **Timer Remaining** | Countdown timestamp sensor showing when the active timer expires |
</details>
<details>
<summary>

### New Services
</summary>

All three services target a `switch` entity from the `hatch_rest` integration (i.e., the Power switch for a given device).

#### `hatch_rest.save_to_favorite`
Saves the device's **current state** (sound, volume, color, brightness) to a favorite slot.

| Field | Type | Required | Description |
|---|---|---|---|
| `index` | number (1–6) | Yes | Favorite slot to overwrite |

#### `hatch_rest.select_favorite`
Activates a favorite slot — equivalent to pressing a preset button on the device.

| Field | Type | Required | Description |
|---|---|---|---|
| `index` | number (1–6) | Yes | Favorite slot to activate |

#### `hatch_rest.send_command`
Sends a raw command string directly to the device. Intended for protocol exploration and debugging.

| Field | Type | Required | Default | Description |
|---|---|---|---|---|
| `command` | text | Yes | — | ASCII command (`"GF"`, `"PGB01"`) or hex bytes if `raw` is true |
| `raw` | boolean | No | `false` | When true, interprets `command` as a hex-encoded byte string and sends the raw bytes |
</details>
<details>
<summary>

### New Protocol Coverage
</summary>

The upstream implementation only read/wrote light color, brightness, sound, and volume. We added:

- **Favorites** — full round-trip: reads all 6 PGB slots on connect, decodes name/sound/volume/color/brightness/enabled per slot, writes the full PS command sequence (PSB→PSC→PSN→PSV→PSL→PSF) to toggle enable/disable without clobbering slot content
- **Schedules** — reads all 10 EGB slots, exposes enabled toggles
- **Timer** — set (SD, in seconds), get (GI/GD), and live countdown via coordinator
- **Active favorite tracking** — GF response attribution with `_pending_gf` guard to distinguish from PSF save confirmation (`"01"`)
</details>


<details>
<summary>

### Images

</summary>

<img width="1082" height="787" alt="Screenshot 2026-04-20 at 21 11 05" src="https://github.com/user-attachments/assets/ed065693-fa24-4c83-a14d-044402217cd5" />

<img width="1019" height="1131" alt="Screenshot 2026-04-20 at 21 10 41" src="https://github.com/user-attachments/assets/4f587d78-b1e5-478c-8231-d4c2e74092a3" />

</details>